### PR TITLE
Fix a few issues

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -163,7 +163,7 @@ namespace DICUI
                     VAR_Switches = "";
                     break;
                 case "IBM PC Compatible(CD - Rom) No Copy Protection":
-                    VAR_Type = "dvd";
+                    VAR_Type = "cd";
                     VAR_Switches = "/c2";
                     break;
                 case "BD-Video":

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -228,14 +228,14 @@ namespace DICUI
             {
                 using (StreamWriter writetext = new StreamWriter("PSX.bat"))
                 {
-                    writetext.WriteLine("edccchk" + " " + "\"" + VAR_OutputDirectory + VAR_OutputFilename + ".bin" + "\" > " + "\"" + VAR_OutputDirectory + "edccchk1.txt");
-                    writetext.WriteLine("edccchk" + " " + "\"" + VAR_OutputDirectory + VAR_OutputFilename + " (Track 1).bin" + "\" > " + "\"" + VAR_OutputDirectory + "edccchk1.txt");
-                    writetext.WriteLine("edccchk" + " " + "\"" + VAR_OutputDirectory + VAR_OutputFilename + " (Track 01).bin" + "\" > " + "\"" + VAR_OutputDirectory + "edccchk1.txt");
-                    writetext.WriteLine("psxt001z" + " " + "\"" + VAR_OutputDirectory + VAR_OutputFilename + ".bin" + "\" > " + "\"" + VAR_OutputDirectory + "psxt001z1.txt");
-                    writetext.WriteLine("psxt001z" + " " + "\"" + VAR_OutputDirectory + VAR_OutputFilename + " (Track 1).bin" + "\" > " + "\"" + VAR_OutputDirectory + "psxt001z2.txt");
-                    writetext.WriteLine("psxt001z" + " " + "\"" + VAR_OutputDirectory + VAR_OutputFilename + " (Track 01).bin" + "\" > " + "\"" + VAR_OutputDirectory + "psxt001z3.txt");
-                    writetext.WriteLine("psxt001z" + " " + "--libcrypt " + "\"" + VAR_OutputDirectory + VAR_OutputFilename + ".sub\" > " + "\"" + VAR_OutputDirectory + "libcrypt.txt");
-                    writetext.WriteLine("psxt001z" + " " + "--libcryptdrvfast " + VAR_DriveLetter + " > " + "\"" + VAR_OutputDirectory + "libcryptdrv.log");
+                    writetext.WriteLine("edccchk" + " " + "\"" + VAR_OutputDirectory + "\\" + VAR_OutputFilename + ".bin" + "\" > " + "\"" + VAR_OutputDirectory + "\\" + "edccchk1.txt");
+                    writetext.WriteLine("edccchk" + " " + "\"" + VAR_OutputDirectory + "\\" + VAR_OutputFilename + " (Track 1).bin" + "\" > " + "\"" + VAR_OutputDirectory + "\\" + "edccchk1.txt");
+                    writetext.WriteLine("edccchk" + " " + "\"" + VAR_OutputDirectory + "\\" + VAR_OutputFilename + " (Track 01).bin" + "\" > " + "\"" + VAR_OutputDirectory + "\\" + "edccchk1.txt");
+                    writetext.WriteLine("psxt001z" + " " + "\"" + VAR_OutputDirectory + "\\" + VAR_OutputFilename + ".bin" + "\" > " + "\"" + VAR_OutputDirectory + "\\" + "psxt001z1.txt");
+                    writetext.WriteLine("psxt001z" + " " + "\"" + VAR_OutputDirectory + "\\" + VAR_OutputFilename + " (Track 1).bin" + "\" > " + "\"" + VAR_OutputDirectory + "\\" + "psxt001z2.txt");
+                    writetext.WriteLine("psxt001z" + " " + "\"" + VAR_OutputDirectory + "\\" + VAR_OutputFilename + " (Track 01).bin" + "\" > " + "\"" + VAR_OutputDirectory + "\\" + "psxt001z3.txt");
+                    writetext.WriteLine("psxt001z" + " " + "--libcrypt " + "\"" + VAR_OutputDirectory + "\\" + VAR_OutputFilename + ".sub\" > " + "\"" + VAR_OutputDirectory + "\\" + "libcrypt.txt");
+                    writetext.WriteLine("psxt001z" + " " + "--libcryptdrvfast " + VAR_DriveLetter + " > " + "\"" + VAR_OutputDirectory + "\\" + "libcryptdrv.log");
                 }
                 Process processpsx = new Process();
                 processpsx.StartInfo.FileName = "PSX.bat";

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -207,7 +207,7 @@ namespace DICUI
                 {
                     Process process = new Process();
                     process.StartInfo.FileName = "Release_ANSI\\DiscImageCreator.exe";
-                    process.StartInfo.Arguments = VAR_Type + " " + VAR_DriveLetter + " " + VAR_OutputDirectory + "\\" + VAR_OutputFilename + " " + VAR_DriveSpeed + " " + VAR_Switches;
+                    process.StartInfo.Arguments = VAR_Type + " " + VAR_DriveLetter + " \"" + VAR_OutputDirectory + "\\" + VAR_OutputFilename + "\" " + VAR_DriveSpeed + " " + VAR_Switches;
                     Console.WriteLine(process.StartInfo.Arguments);
                     process.Start();
                     process.WaitForExit();


### PR DESCRIPTION
Fixed a few issues I found:
1. PC CD (no copy protection) had type set to dvd
2. Output path wasn't quoted when running DiscImageCreator
3. PSX.bat was missing backslashes after output directory