### PR TITLE
Combine IBM PC-CD options, misc fixes

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -66,11 +66,8 @@
                 <ComboBoxItem Content="Apple Macintosh (CD-Rom)"/>
                 <ComboBoxItem Content="Apple Macintosh (DVD-Rom)"/>
                 <ComboBoxItem Content="Fujitsu FM Towns series"/>
-                <ComboBoxItem Content="IBM PC Compatible (CD-Rom) No Copy Protection"/>
-                <ComboBoxItem Content="IBM PC Compatible (CD-Rom) SecuROM"/>
-                <ComboBoxItem Content="IBM PC Compatible (CD-Rom) Detectable Protection"/>
-                <ComboBoxItem Content="IBM PC Compatible (CD-Rom) C2 Error Protection"/>
-                <ComboBoxItem Content="IBM PC Compatible (DVD-Rom)"/>
+				<ComboBoxItem Content="IBM PC Compatible (CD-Rom)"/>
+				<ComboBoxItem Content="IBM PC Compatible (DVD-Rom)"/>
                 <ComboBoxItem Content="NEC PC-88"/>
                 <ComboBoxItem Content="NEC PC-98"/>
                 <ComboBoxItem Content="---------- Arcade ----------" IsEnabled="False"/>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -66,8 +66,8 @@
                 <ComboBoxItem Content="Apple Macintosh (CD-Rom)"/>
                 <ComboBoxItem Content="Apple Macintosh (DVD-Rom)"/>
                 <ComboBoxItem Content="Fujitsu FM Towns series"/>
-				<ComboBoxItem Content="IBM PC Compatible (CD-Rom)"/>
-				<ComboBoxItem Content="IBM PC Compatible (DVD-Rom)"/>
+                <ComboBoxItem Content="IBM PC Compatible (CD-Rom)"/>
+                <ComboBoxItem Content="IBM PC Compatible (DVD-Rom)"/>
                 <ComboBoxItem Content="NEC PC-88"/>
                 <ComboBoxItem Content="NEC PC-98"/>
                 <ComboBoxItem Content="---------- Arcade ----------" IsEnabled="False"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -188,22 +188,9 @@ namespace DICUI
                     VAR_Type = "cd";
                     VAR_Switches = "/c2";
                     break;
-                // TODO: Can protection be determined by a check automatically?
-                case "IBM PC Compatible (CD-Rom) No Copy Protection":
-                    VAR_Type = "dvd";
-                    VAR_Switches = "/c2";
-                    break;
-                case "IBM PC Compatible (CD-Rom) SecuROM":
+                case "IBM PC Compatible (CD-Rom)":
                     VAR_Type = "cd";
-                    VAR_Switches = "/c2 /ns";
-                    break;
-                case "IBM PC Compatible (CD-Rom) Detectable Protection":
-                    VAR_Type = "cd";
-                    VAR_Switches = "/c2 /sf";
-                    break;
-                case "IBM PC Compatible (CD-Rom) C2 Error Protection":
-                    VAR_Type = "cd";
-                    VAR_Switches = "/c2 /ss";
+                    VAR_Switches = "/c2 /ns /sf /ss";
                     break;
                 case "IBM PC Compatible (DVD-Rom)":
                     VAR_Type = "dvd";

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -241,14 +241,11 @@ namespace DICUI
                 #region Others
 
                 case "Audio CD":
-                    VAR_Type = "audio";
-
-                case "IBM PC Compatible(CD - Rom) No Copy Protection":
                     VAR_Type = "cd";
-
                     VAR_Switches = "/c2";
                     break;
                 case "BD-Video":
+					VAR_Type = "bd";
                     VAR_Switches = "";
                     break;
                 case "DVD-Video":

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -245,7 +245,7 @@ namespace DICUI
                     VAR_Switches = "/c2";
                     break;
                 case "BD-Video":
-					VAR_Type = "bd";
+                    VAR_Type = "bd";
                     VAR_Switches = "";
                     break;
                 case "DVD-Video":


### PR DESCRIPTION
This commit consolidates the 4 IBM PC-CD variants into a single option. This will reduce the amount of confusion to new users in the future since they will be able to dump any CD right off the bat. The other commits dealt with merge issues I had due to not syncing branches before making my changes. I believe I also added "bd" as the type for BD-Video and changed the Audio CD type to "cd", since the "audio" command is more fiddly than it seems.