### PR TITLE
 Enable future settings use

### DIFF
--- a/App.config
+++ b/App.config
@@ -1,6 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+    <configSections>
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="DICUI.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
     </startup>
+    <userSettings>
+        <DICUI.Properties.Settings>
+            <setting name="DiscImageCreatorLocation" serializeAs="String">
+                <value>Release_ANSI\\DiscImageCreator.exe</value>
+            </setting>
+        </DICUI.Properties.Settings>
+    </userSettings>
 </configuration>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -93,8 +93,8 @@
                 <ComboBoxItem Content="8"/>
                 <ComboBoxItem Content="16"/>
                 <ComboBoxItem Content="48"/>
-                <ComboBoxItem Content="Custom"/>
-            </ComboBox>
+				<ComboBoxItem Content="Custom"/>
+			</ComboBox>
 
 
         </Grid>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -93,8 +93,8 @@
                 <ComboBoxItem Content="8"/>
                 <ComboBoxItem Content="16"/>
                 <ComboBoxItem Content="48"/>
-				<ComboBoxItem Content="Custom"/>
-			</ComboBox>
+                <ComboBoxItem Content="Custom"/>
+            </ComboBox>
 
 
         </Grid>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -291,7 +291,7 @@ namespace DICUI
                 () =>
                 {
                     Process process = new Process();
-                    process.StartInfo.FileName = "Release_ANSI\\DiscImageCreator.exe";
+                    process.StartInfo.FileName = Properties.Settings.Default.DiscImageCreatorLocation; // TODO: Make this configurable in UI
                     process.StartInfo.Arguments = VAR_Type + " " + VAR_DriveLetter + " \"" + VAR_OutputDirectory + "\\" + VAR_OutputFilename + "\" " + VAR_DriveSpeed + " " + VAR_Switches;
                     Console.WriteLine(process.StartInfo.Arguments);
                     process.Start();
@@ -300,6 +300,7 @@ namespace DICUI
 
             if (VAR_IsXBOXorPS4 == true)
             {
+				// TODO: Add random string / GUID to end of batch file name so that multiple instances can run at once
                 using (StreamWriter writetext = new StreamWriter("PS4orXBOXONE.bat"))
                 {
                     writetext.WriteLine("sg_raw.exe -v -r 4100 -R " + VAR_DriveLetter + ":" + "ad 01 00 00 00 00 00 00 10 04 00 00 -o \"PIC.bin\"");
@@ -311,7 +312,8 @@ namespace DICUI
             }
             if (VAR_IsPSX == true)
             {
-                using (StreamWriter writetext = new StreamWriter("PSX.bat"))
+				// TODO: Add random string / GUID to end of batch file name so that multiple instances can run at once
+				using (StreamWriter writetext = new StreamWriter("PSX.bat"))
                 {
                     writetext.WriteLine("edccchk" + " " + "\"" + VAR_OutputDirectory + "\\" + VAR_OutputFilename + ".bin" + "\" > " + "\"" + VAR_OutputDirectory + "\\" + "edccchk1.txt");
                     writetext.WriteLine("edccchk" + " " + "\"" + VAR_OutputDirectory + "\\" + VAR_OutputFilename + " (Track 1).bin" + "\" > " + "\"" + VAR_OutputDirectory + "\\" + "edccchk1.txt");
@@ -328,9 +330,6 @@ namespace DICUI
                 processpsx.WaitForExit();
             }
             BTN_Start.IsEnabled = true;
-
-
-
         }
 
         public MainWindow()
@@ -361,12 +360,12 @@ namespace DICUI
 
         private void CB_DriveSpeed_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
         {
+			// TODO: Figure out how to keep the list of items while also allowing the custom input
             if (CB_DriveSpeed.SelectedIndex == 4)
             {
-                CB_DriveSpeed.Items.Clear();
-                CB_DriveSpeed.IsEditable = true;
-                
-            }
+				CB_DriveSpeed.Items.Clear();
+				CB_DriveSpeed.IsEditable = true;
+			}
         }
     }
 }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -300,7 +300,7 @@ namespace DICUI
 
             if (VAR_IsXBOXorPS4 == true)
             {
-				// TODO: Add random string / GUID to end of batch file name so that multiple instances can run at once
+                // TODO: Add random string / GUID to end of batch file name so that multiple instances can run at once
                 using (StreamWriter writetext = new StreamWriter("PS4orXBOXONE.bat"))
                 {
                     writetext.WriteLine("sg_raw.exe -v -r 4100 -R " + VAR_DriveLetter + ":" + "ad 01 00 00 00 00 00 00 10 04 00 00 -o \"PIC.bin\"");
@@ -312,8 +312,8 @@ namespace DICUI
             }
             if (VAR_IsPSX == true)
             {
-				// TODO: Add random string / GUID to end of batch file name so that multiple instances can run at once
-				using (StreamWriter writetext = new StreamWriter("PSX.bat"))
+                // TODO: Add random string / GUID to end of batch file name so that multiple instances can run at once
+                using (StreamWriter writetext = new StreamWriter("PSX.bat"))
                 {
                     writetext.WriteLine("edccchk" + " " + "\"" + VAR_OutputDirectory + "\\" + VAR_OutputFilename + ".bin" + "\" > " + "\"" + VAR_OutputDirectory + "\\" + "edccchk1.txt");
                     writetext.WriteLine("edccchk" + " " + "\"" + VAR_OutputDirectory + "\\" + VAR_OutputFilename + " (Track 1).bin" + "\" > " + "\"" + VAR_OutputDirectory + "\\" + "edccchk1.txt");
@@ -360,12 +360,12 @@ namespace DICUI
 
         private void CB_DriveSpeed_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
         {
-			// TODO: Figure out how to keep the list of items while also allowing the custom input
+            // TODO: Figure out how to keep the list of items while also allowing the custom input
             if (CB_DriveSpeed.SelectedIndex == 4)
             {
-				CB_DriveSpeed.Items.Clear();
-				CB_DriveSpeed.IsEditable = true;
-			}
+                CB_DriveSpeed.Items.Clear();
+                CB_DriveSpeed.IsEditable = true;
+            }
         }
     }
 }

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace DICUI.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.5.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -20,6 +20,18 @@ namespace DICUI.Properties {
         public static Settings Default {
             get {
                 return defaultInstance;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Release_ANSI\\\\DiscImageCreator.exe")]
+        public string DiscImageCreatorLocation {
+            get {
+                return ((string)(this["DiscImageCreatorLocation"]));
+            }
+            set {
+                this["DiscImageCreatorLocation"] = value;
             }
         }
     }

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -1,7 +1,9 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="uri:settings" CurrentProfile="(Default)">
-  <Profiles>
-    <Profile Name="(Default)" />
-  </Profiles>
-  <Settings />
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="DICUI.Properties" GeneratedClassName="Settings">
+  <Profiles />
+  <Settings>
+    <Setting Name="DiscImageCreatorLocation" Type="System.String" Scope="User">
+      <Value Profile="(Default)">Release_ANSI\\DiscImageCreator.exe</Value>
+    </Setting>
+  </Settings>
 </SettingsFile>


### PR DESCRIPTION
This change converts the static DIC path to one that is controlled by settings. Currently, nothing saves or changes these settings so nothing has changed in terms of what the workflow is. This will, however, enable these settings to be controlled through the UI in the future, and allow for settings persistence between sessions without having to rely on AppData or the registry.