### PR TITLE
Add Enumerations; Helper Methods

### DIFF
--- a/DICUI.csproj
+++ b/DICUI.csproj
@@ -87,6 +87,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Utilities.cs" />
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -95,6 +96,7 @@
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Enumerations.cs" />
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Enumerations.cs
+++ b/Enumerations.cs
@@ -1,0 +1,107 @@
+﻿namespace DICUI
+{
+	/// <summary>
+	/// Known disc types
+	/// </summary>
+	public enum DiscType
+	{
+		NONE = 0,
+		CD,
+		DVD5,
+		DVD9,
+		GDROM,
+		HDDVD,
+		BD25,
+		BD50,
+
+		// Special Formats
+		GameCubeGameDisc,
+		UMD,
+		
+		// Keeping this separate since it's currently unsupported in the UI
+		Floppy = 99,
+	}
+
+	/// <summary>
+	/// Known systems
+	/// </summary>
+	/// <remarks>Ensure that Utilities methods are updated as well</remarks>
+	public enum System
+	{
+		NONE = 0,
+
+		#region Consoles
+
+		BandaiPlaydiaQuickInteractiveSystem,
+		BandaiApplePippin,
+		CommodoreAmigaCD32,
+		CommodoreAmigaCDTV,
+		MattelHyperscan,
+		MicrosoftXBOX,
+		MicrosoftXBOX360,
+		MicrosoftXBOXOne,
+		NECPCEngineTurboGrafxCD,
+		NECPCFX,
+		NintendoGameCube,
+		NintendoWii,
+		NintendoWiiU,
+		Panasonic3DOInteractiveMultiplayer,
+		PhilipsCDi,
+		SegaCDMegaCD,
+		SegaDreamcast,
+		SegaSaturn,
+		SNKNeoGeoCD,
+		SonyPlayStation,
+		SonyPlayStation2,
+		SonyPlayStation3,
+		SonyPlayStation4,
+		SonyPlayStationPortable,
+		VMLabsNuon,
+		VTechVFlashVSmilePro,
+		ZAPiTGamesGameWaveFamilyEntertainmentSystem,
+
+		#endregion
+
+		#region Computers
+
+		AcornArchimedes,
+		AppleMacintosh,
+		CommodoreAmigaCD,
+		FujitsuFMTowns,
+		IBMPCCompatible,
+		NECPC88,
+		NECPC98,
+		SharpX68000,
+
+		#endregion
+
+		#region Arcade
+
+		NamcoSegaNintendoTriforce,
+		NamcoSystem246,
+		SegaChihiro,
+		SegaLindbergh,
+		SegaNaomi,
+		SegaNaomi2,
+		TABAustriaQuizard,
+		TandyMemorexVisualInformationSystem,
+
+		#endregion
+
+		#region Other
+
+		AudioCD,
+		BDVideo,
+		DVDVideo,
+		EnhancedCD,
+		PalmOS,
+		PhilipsCDiDigitalVideo,
+		PhotoCD,
+		PlayStationGameSharkUpdates,
+		TaoiKTV,
+		TomyKissSite,
+		VideoCD,
+
+		#endregion
+	}
+}

--- a/Enumerations.cs
+++ b/Enumerations.cs
@@ -26,7 +26,7 @@
 	/// Known systems
 	/// </summary>
 	/// <remarks>Ensure that Utilities methods are updated as well</remarks>
-	public enum System
+	public enum KnownSystem
 	{
 		NONE = 0,
 

--- a/Enumerations.cs
+++ b/Enumerations.cs
@@ -1,107 +1,107 @@
 ﻿namespace DICUI
 {
-	/// <summary>
-	/// Known disc types
-	/// </summary>
-	public enum DiscType
-	{
-		NONE = 0,
-		CD,
-		DVD5,
-		DVD9,
-		GDROM,
-		HDDVD,
-		BD25,
-		BD50,
+    /// <summary>
+    /// Known disc types
+    /// </summary>
+    public enum DiscType
+    {
+        NONE = 0,
+        CD,
+        DVD5,
+        DVD9,
+        GDROM,
+        HDDVD,
+        BD25,
+        BD50,
 
-		// Special Formats
-		GameCubeGameDisc,
-		UMD,
-		
-		// Keeping this separate since it's currently unsupported in the UI
-		Floppy = 99,
-	}
+        // Special Formats
+        GameCubeGameDisc,
+        UMD,
+        
+        // Keeping this separate since it's currently unsupported in the UI
+        Floppy = 99,
+    }
 
-	/// <summary>
-	/// Known systems
-	/// </summary>
-	/// <remarks>Ensure that Utilities methods are updated as well</remarks>
-	public enum KnownSystem
-	{
-		NONE = 0,
+    /// <summary>
+    /// Known systems
+    /// </summary>
+    /// <remarks>Ensure that Utilities methods are updated as well</remarks>
+    public enum KnownSystem
+    {
+        NONE = 0,
 
-		#region Consoles
+        #region Consoles
 
-		BandaiPlaydiaQuickInteractiveSystem,
-		BandaiApplePippin,
-		CommodoreAmigaCD32,
-		CommodoreAmigaCDTV,
-		MattelHyperscan,
-		MicrosoftXBOX,
-		MicrosoftXBOX360,
-		MicrosoftXBOXOne,
-		NECPCEngineTurboGrafxCD,
-		NECPCFX,
-		NintendoGameCube,
-		NintendoWii,
-		NintendoWiiU,
-		Panasonic3DOInteractiveMultiplayer,
-		PhilipsCDi,
-		SegaCDMegaCD,
-		SegaDreamcast,
-		SegaSaturn,
-		SNKNeoGeoCD,
-		SonyPlayStation,
-		SonyPlayStation2,
-		SonyPlayStation3,
-		SonyPlayStation4,
-		SonyPlayStationPortable,
-		VMLabsNuon,
-		VTechVFlashVSmilePro,
-		ZAPiTGamesGameWaveFamilyEntertainmentSystem,
+        BandaiPlaydiaQuickInteractiveSystem,
+        BandaiApplePippin,
+        CommodoreAmigaCD32,
+        CommodoreAmigaCDTV,
+        MattelHyperscan,
+        MicrosoftXBOX,
+        MicrosoftXBOX360,
+        MicrosoftXBOXOne,
+        NECPCEngineTurboGrafxCD,
+        NECPCFX,
+        NintendoGameCube,
+        NintendoWii,
+        NintendoWiiU,
+        Panasonic3DOInteractiveMultiplayer,
+        PhilipsCDi,
+        SegaCDMegaCD,
+        SegaDreamcast,
+        SegaSaturn,
+        SNKNeoGeoCD,
+        SonyPlayStation,
+        SonyPlayStation2,
+        SonyPlayStation3,
+        SonyPlayStation4,
+        SonyPlayStationPortable,
+        VMLabsNuon,
+        VTechVFlashVSmilePro,
+        ZAPiTGamesGameWaveFamilyEntertainmentSystem,
 
-		#endregion
+        #endregion
 
-		#region Computers
+        #region Computers
 
-		AcornArchimedes,
-		AppleMacintosh,
-		CommodoreAmigaCD,
-		FujitsuFMTowns,
-		IBMPCCompatible,
-		NECPC88,
-		NECPC98,
-		SharpX68000,
+        AcornArchimedes,
+        AppleMacintosh,
+        CommodoreAmigaCD,
+        FujitsuFMTowns,
+        IBMPCCompatible,
+        NECPC88,
+        NECPC98,
+        SharpX68000,
 
-		#endregion
+        #endregion
 
-		#region Arcade
+        #region Arcade
 
-		NamcoSegaNintendoTriforce,
-		NamcoSystem246,
-		SegaChihiro,
-		SegaLindbergh,
-		SegaNaomi,
-		SegaNaomi2,
-		TABAustriaQuizard,
-		TandyMemorexVisualInformationSystem,
+        NamcoSegaNintendoTriforce,
+        NamcoSystem246,
+        SegaChihiro,
+        SegaLindbergh,
+        SegaNaomi,
+        SegaNaomi2,
+        TABAustriaQuizard,
+        TandyMemorexVisualInformationSystem,
 
-		#endregion
+        #endregion
 
-		#region Other
+        #region Other
 
-		AudioCD,
-		BDVideo,
-		DVDVideo,
-		EnhancedCD,
-		PalmOS,
-		PhilipsCDiDigitalVideo,
-		PhotoCD,
-		PlayStationGameSharkUpdates,
-		TaoiKTV,
-		TomyKissSite,
-		VideoCD,
+        AudioCD,
+        BDVideo,
+        DVDVideo,
+        EnhancedCD,
+        PalmOS,
+        PhilipsCDiDigitalVideo,
+        PhotoCD,
+        PlayStationGameSharkUpdates,
+        TaoiKTV,
+        TomyKissSite,
+        VideoCD,
 
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -43,46 +43,7 @@
             <Label Grid.Row="4" Grid.Column="0" VerticalAlignment="Center">Drive Letter</Label>
             <Label Grid.Row="5" Grid.Column="0" VerticalAlignment="Center">Drive Speed</Label>
 
-            <ComboBox x:Name="cmb_DiscType" Grid.Row="0" Grid.Column="1" Height="22" Text="Bandai Playdia Quick Interactive System" DropDownClosed="cmb_DiscType_DropDownClosed" SelectionChanged="cmb_DiscType_SelectionChanged">
-                <ComboBoxItem Content="Unknown"/>
-                <ComboBoxItem Content="---------- Consoles ----------" IsEnabled="False"/>
-                <ComboBoxItem Content="Bandai Playdia Quick Interactive System"/>
-                <ComboBoxItem Content="Bandai / Apple Pippin"/>
-                <ComboBoxItem Content="Commodore Amiga CD / CD32 / CDTV"/>
-                <ComboBoxItem Content="Mattel HyperScan"/>
-                <ComboBoxItem Content="Microsoft XBOX One"/>
-                <ComboBoxItem Content="NEC PC-Engine / TurboGrafx CD"/>
-                <ComboBoxItem Content="NEC PC-FX / PC-FXGA"/>
-                <ComboBoxItem Content="Panasonic 3DO"/>
-                <ComboBoxItem Content="Philips CD-i"/>
-                <ComboBoxItem Content="Sega CD / Mega CD"/>
-                <ComboBoxItem Content="Sega Saturn"/>
-                <ComboBoxItem Content="SNK Neo Geo CD"/>
-                <ComboBoxItem Content="Sony PlayStation"/>
-                <ComboBoxItem Content="Sony PlayStation 2 (CD-Rom)"/>
-                <ComboBoxItem Content="Sony PlayStation 2 (DVD-Rom)"/>
-                <ComboBoxItem Content="Sony PlayStation 4"/>
-                <ComboBoxItem Content="VTech V.Flash - V.Smile Pro"/>
-                <ComboBoxItem Content="---------- Computers ----------" IsEnabled="False"/>
-                <ComboBoxItem Content="Apple Macintosh (CD-Rom)"/>
-                <ComboBoxItem Content="Apple Macintosh (DVD-Rom)"/>
-                <ComboBoxItem Content="Fujitsu FM Towns series"/>
-                <ComboBoxItem Content="IBM PC Compatible (CD-Rom)"/>
-                <ComboBoxItem Content="IBM PC Compatible (DVD-Rom)"/>
-                <ComboBoxItem Content="NEC PC-88"/>
-                <ComboBoxItem Content="NEC PC-98"/>
-                <ComboBoxItem Content="---------- Arcade ----------" IsEnabled="False"/>
-                <ComboBoxItem Content="Sega Lindbergh"/>
-                <ComboBoxItem Content="---------- Others ----------" IsEnabled="False"/>
-                <ComboBoxItem Content="Audio CD"/>
-                <ComboBoxItem Content="BD-Video"/>
-                <ComboBoxItem Content="DVD-Video"/>
-                <ComboBoxItem Content="PalmOS"/>
-                <ComboBoxItem Content="Photo CD"/>
-                <ComboBoxItem Content="PlayStation GameShark Updates"/>
-                <ComboBoxItem Content="Tomy Kiss-Site"/>
-                <ComboBoxItem Content="Video CD"/>
-            </ComboBox>
+            <ComboBox x:Name="cmb_DiscType" Grid.Row="0" Grid.Column="1" Height="22" DropDownClosed="cmb_DiscType_DropDownClosed" SelectionChanged="cmb_DiscType_SelectionChanged" />
 
             <TextBox x:Name="TXT_DiscImageCreatorPath" Grid.Row="1" Grid.Column="1" Height="22" Width="345" HorizontalAlignment="left" IsEnabled="False" ></TextBox>
             <Button x:Name="BTN_DiscImageCreatorBrowse" Grid.Row="1" Grid.Column="1" Height="22" Width="50" HorizontalAlignment="Right" Content="Browse" IsEnabled="False"></Button>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -193,13 +193,11 @@ namespace DICUI
 
         private void cmb_DiscType_DropDownClosed(object sender, EventArgs e)
         {
-            switch (Convert.ToString(cmb_DiscType.Text))
+			var tuple = cmb_DiscType.SelectedItem as Tuple<string, KnownSystem?, DiscType?>;
+			switch (tuple.Item2)
             {
-                case "Sony PlayStation 4":
-                    cmb_DriveSpeed.Items.Clear();
-                    cmb_DriveSpeed.IsEnabled = false;
-                    break;
-                case "Microsoft XBOX One":
+				case KnownSystem.MicrosoftXBOXOne:
+				case KnownSystem.SonyPlayStation4:
                     cmb_DriveSpeed.Items.Clear();
                     cmb_DriveSpeed.IsEnabled = false;
                     break;

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -240,7 +240,6 @@ namespace DICUI
                 case "TAB-Austria Quizard":
                     // Placeholder for later use
                     break;
-
                 case "Tandy / Memorex Visual Information System":
                     // Placeholder for later use
                     break;

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -13,7 +13,7 @@ namespace DICUI
     public partial class MainWindow : Window
     {
         private const string dicPath = "Programs\\DiscImageCreator.exe"; // TODO: Make configurable in UI or in Settings
-		private List<Tuple<string, KnownSystem?, DiscType?>> _systems { get; set; }
+        private List<Tuple<string, KnownSystem?, DiscType?>> _systems { get; set; }
 
         public void ScanForDisk()
         {
@@ -35,12 +35,14 @@ namespace DICUI
                     lbl_Status.Content = "CD or DVD found ! Choose your Disc Type";
                     btn_Start.IsEnabled = true;
                     cmb_DriveSpeed.Text = "8";
+                    break;
                 }
                 else
                 {
                     lbl_Status.Content = "No CD or DVD found !";
                 }
-            btn_Search.IsEnabled = true;
+
+                btn_Search.IsEnabled = true;
             }
         }
 
@@ -58,17 +60,17 @@ namespace DICUI
 
         public async void StartDumping()
         {
-			// Local variables
+            // Local variables
             string driveLetter = cmb_DriveLetter.Text;
-			string outputDirectory = txt_OutputDirectory.Text;
-			string outputFileName = txt_OutputFilename.Text;
-			string driveSpeed = cmb_DriveSpeed.Text;
+            string outputDirectory = txt_OutputDirectory.Text;
+            string outputFileName = txt_OutputFilename.Text;
+            string driveSpeed = cmb_DriveSpeed.Text;
             btn_Start.IsEnabled = false;
 
-			// Get the discType and processArguments from a given system and disc combo
-			var selected = cmb_DiscType.SelectedValue as Tuple<string, KnownSystem?, DiscType?>;
-			string discType = Utilities.GetBaseCommand(selected.Item3);
-			string processArguments = string.Join(" ", Utilities.GetDefaultParameters(selected.Item2, selected.Item3));
+            // Get the discType and processArguments from a given system and disc combo
+            var selected = cmb_DiscType.SelectedValue as Tuple<string, KnownSystem?, DiscType?>;
+            string discType = Utilities.GetBaseCommand(selected.Item3);
+            string processArguments = string.Join(" ", Utilities.GetDefaultParameters(selected.Item2, selected.Item3));
 
             await Task.Run(
                 () =>
@@ -81,41 +83,41 @@ namespace DICUI
                     process.WaitForExit();
                 });
 
-			// Special cases
-			string guid = Guid.NewGuid().ToString();
-			switch (selected.Item2)
-			{
-				case KnownSystem.MicrosoftXBOXOne:
-				case KnownSystem.SonyPlayStation4:
-					// TODO: Direct invocation of program instead of via Batch File
-					using (StreamWriter writetext = new StreamWriter("XboneOrPS4" + guid + ".bat"))
-					{
-						writetext.WriteLine("sg_raw.exe -v -r 4100 -R " + driveLetter + ": " + "ad 01 00 00 00 00 00 00 10 04 00 00 -o \"PIC.bin\"");
-					}
-					Process processXboneOrPS4 = new Process();
-					processXboneOrPS4.StartInfo.FileName = "XboneOrPS4" + guid + ".bat";
-					processXboneOrPS4.Start();
-					processXboneOrPS4.WaitForExit();
-					break;
-				case KnownSystem.SonyPlayStation:
-					// TODO: Direct invocation of program instead of via Batch File
-					using (StreamWriter writetext = new StreamWriter("PSX" + guid + ".bat"))
-					{
-						writetext.WriteLine("edccchk" + " " + "\"" + outputDirectory + "\\" + outputFileName + ".bin" + "\" > " + "\"" + outputDirectory + "\\" + "edccchk1.txt");
-						writetext.WriteLine("edccchk" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 1).bin" + "\" > " + "\"" + outputDirectory + "\\" + "edccchk1.txt");
-						writetext.WriteLine("edccchk" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 01).bin" + "\" > " + "\"" + outputDirectory + "\\" + "edccchk1.txt");
-						writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + ".bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z1.txt");
-						writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 1).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z2.txt");
-						writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 01).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z3.txt");
-						writetext.WriteLine("psxt001z" + " " + "--libcrypt " + "\"" + outputDirectory + "\\" + outputFileName + ".sub\" > " + "\"" + outputDirectory + "\\" + "libcrypt.txt");
-						writetext.WriteLine("psxt001z" + " " + "--libcryptdrvfast " + driveLetter + " > " + "\"" + outputDirectory + "\\" + "libcryptdrv.log");
-					}
-					Process processpsx = new Process();
-					processpsx.StartInfo.FileName = "PSX" + guid + ".bat";
-					processpsx.Start();
-					processpsx.WaitForExit();
-					break;
-			}
+            // Special cases
+            string guid = Guid.NewGuid().ToString();
+            switch (selected.Item2)
+            {
+                case KnownSystem.MicrosoftXBOXOne:
+                case KnownSystem.SonyPlayStation4:
+                    // TODO: Direct invocation of program instead of via Batch File
+                    using (StreamWriter writetext = new StreamWriter("XboneOrPS4" + guid + ".bat"))
+                    {
+                        writetext.WriteLine("sg_raw.exe -v -r 4100 -R " + driveLetter + ": " + "ad 01 00 00 00 00 00 00 10 04 00 00 -o \"PIC.bin\"");
+                    }
+                    Process processXboneOrPS4 = new Process();
+                    processXboneOrPS4.StartInfo.FileName = "XboneOrPS4" + guid + ".bat";
+                    processXboneOrPS4.Start();
+                    processXboneOrPS4.WaitForExit();
+                    break;
+                case KnownSystem.SonyPlayStation:
+                    // TODO: Direct invocation of program instead of via Batch File
+                    using (StreamWriter writetext = new StreamWriter("PSX" + guid + ".bat"))
+                    {
+                        writetext.WriteLine("edccchk" + " " + "\"" + outputDirectory + "\\" + outputFileName + ".bin" + "\" > " + "\"" + outputDirectory + "\\" + "edccchk1.txt");
+                        writetext.WriteLine("edccchk" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 1).bin" + "\" > " + "\"" + outputDirectory + "\\" + "edccchk1.txt");
+                        writetext.WriteLine("edccchk" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 01).bin" + "\" > " + "\"" + outputDirectory + "\\" + "edccchk1.txt");
+                        writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + ".bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z1.txt");
+                        writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 1).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z2.txt");
+                        writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 01).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z3.txt");
+                        writetext.WriteLine("psxt001z" + " " + "--libcrypt " + "\"" + outputDirectory + "\\" + outputFileName + ".sub\" > " + "\"" + outputDirectory + "\\" + "libcrypt.txt");
+                        writetext.WriteLine("psxt001z" + " " + "--libcryptdrvfast " + driveLetter + " > " + "\"" + outputDirectory + "\\" + "libcryptdrv.log");
+                    }
+                    Process processpsx = new Process();
+                    processpsx.StartInfo.FileName = "PSX" + guid + ".bat";
+                    processpsx.Start();
+                    processpsx.WaitForExit();
+                    break;
+            }
 
             btn_Start.IsEnabled = true;
         }
@@ -124,11 +126,12 @@ namespace DICUI
         {
             InitializeComponent();
 
-			// Populate the list of systems and add it to the combo box
-			_systems = Utilities.CreateListOfSystems();
-			cmb_DiscType.ItemsSource = _systems;
-			cmb_DiscType.DisplayMemberPath = "Item1";
-			cmb_DiscType.SelectedIndex = 0;
+            // Populate the list of systems and add it to the combo box
+            _systems = Utilities.CreateListOfSystems();
+            cmb_DiscType.ItemsSource = _systems;
+            cmb_DiscType.DisplayMemberPath = "Item1";
+            cmb_DiscType.SelectedIndex = 0;
+            cmb_DiscType_SelectionChanged(null, null);
 
             ScanForDisk();
         }
@@ -150,14 +153,32 @@ namespace DICUI
 
         private void cmb_DiscType_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-			// If we're on a separator, go to the next item
-			var tuple = cmb_DiscType.SelectedItem as Tuple<string, KnownSystem?, DiscType?>;
-			if (tuple.Item2 == null && tuple.Item3 == null)
-			{
-				cmb_DiscType.SelectedIndex++;
-			}
+            // If we're on a separator, go to the next item
+            var tuple = cmb_DiscType.SelectedItem as Tuple<string, KnownSystem?, DiscType?>;
+            if (tuple.Item2 == null && tuple.Item3 == null)
+            {
+                cmb_DiscType.SelectedIndex++;
+                tuple = cmb_DiscType.SelectedItem as Tuple<string, KnownSystem?, DiscType?>;
+            }
 
-            lbl_Status.Content = "Ready to dump";
+            // If we're on an unsupported type, update the status accordingly
+            switch (tuple.Item3)
+            {
+                case DiscType.NONE:
+                    lbl_Status.Content = "Please select a valid disc type";
+                    break;
+                case DiscType.GDROM:
+                    lbl_Status.Content = string.Format("{0} discs are partially supported by DIC", Utilities.DiscTypeToString(tuple.Item3));
+                    break;
+                case DiscType.GameCubeGameDisc:
+                case DiscType.HDDVD:
+                case DiscType.UMD:
+                    lbl_Status.Content = string.Format("{0} discs are not currently supported by DIC", Utilities.DiscTypeToString(tuple.Item3));
+                    break;
+                default:
+                    lbl_Status.Content = string.Format("{0} ready to dump", Utilities.DiscTypeToString(tuple.Item3));
+                    break;
+            }
         }
 
         private void cmb_DriveSpeed_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,26 +1,19 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using System.Windows.Controls;
 using System.IO;
 using WinForms = System.Windows.Forms;
 using System.Diagnostics;
 using System.Threading.Tasks;
 
-
 namespace DICUI
 {
-
     public partial class MainWindow : Window
     {
-        public String discType;
-        public String processArguments;
-        public String dicPath = "Programs\\DiscImageCreator.exe";
-        public String driveLetter;
-        public String outputDirectory;
-        public String outputFileName;
-        public String driveSpeed;
-        public Boolean isPSX = false;
-        public Boolean isXboneOrPS4 = false;
+        private const string dicPath = "Programs\\DiscImageCreator.exe"; // TODO: Make configurable in UI or in Settings
+		private List<Tuple<string, KnownSystem?, DiscType?>> _systems { get; set; }
 
         public void ScanForDisk()
         {
@@ -65,284 +58,78 @@ namespace DICUI
 
         public async void StartDumping()
         {
-
-            driveLetter = cmb_DriveLetter.Text;
-            outputDirectory = txt_OutputDirectory.Text;
-            outputFileName = txt_OutputFilename.Text;
-            driveSpeed = cmb_DriveSpeed.Text;
+			// Local variables
+            string driveLetter = cmb_DriveLetter.Text;
+			string outputDirectory = txt_OutputDirectory.Text;
+			string outputFileName = txt_OutputFilename.Text;
+			string driveSpeed = cmb_DriveSpeed.Text;
             btn_Start.IsEnabled = false;
 
-            switch (Convert.ToString(cmb_DiscType.Text))
-            {
-                #region Consoles
-
-                case "Bandai Playdia Quick Interactive System":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "Bandai / Apple Pippin":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "Commodore Amiga CD / CD32 / CDTV":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "Mattel HyperScan":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "Microsoft XBOX":
-                    // Placeholder for later use
-                    break;
-                case "Microsoft XBOX 360":
-                    // Placeholder for later use
-                    break;
-                case "Microsoft XBOX One":
-                    discType = "bd";
-                    processArguments = "";
-                    isXboneOrPS4 = true;
-                    break;
-                case "NEC PC-Engine / TurboGrafx CD":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "NEC PC-FX / PC-FXGA":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "Nintendo GameCube":
-                    // Placeholder for later use
-                    break;
-                case "Nintendo Wii":
-                    // Placeholder for later use
-                    break;
-                case "Nintendo Wii U":
-                    // Placeholder for later use
-                    break;
-                case "Panasonic 3DO":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "Philips CD-i":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "Sega CD / Mega CD":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "Sega Dreamcast":
-                    // Placeholder for later use
-                    break;
-                case "Sega Saturn":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "SNK Neo Geo CD":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "Sony PlayStation":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    isPSX = true;
-                    break;
-                case "Sony PlayStation 2 (CD-Rom)":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "Sony PlayStation 2 (DVD-Rom)":
-                    discType = "dvd";
-                    processArguments = "";
-                    break;
-                case "Sony PlayStation 3":
-                    // Placeholder for later use
-                    break;
-                case "Sony PlayStation 4":
-                    discType = "bd";
-                    processArguments = "";
-                    isXboneOrPS4 = true;
-                    break;
-                case "Sony PlayStation Portable":
-                    // No-op - PSP can't be dumped with DIC
-                    break;
-                case "VM Labs NUON":
-                    // Placeholder for later use
-                    break;
-                case "VTech V.Flash - V.Smile Pro":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "ZAPiT Games Game Wave Family Entertainment System":
-                    // Placeholder for later use
-                    break;
-
-                #endregion
-
-                #region Computers
-
-                case "Acorn Archimedes":
-                    // Placeholder for later use
-                    break;
-                case "Apple Macintosh (CD-Rom)":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "Apple Macintosh (DVD-Rom)":
-                    discType = "dvd";
-                    processArguments = "";
-                    break;
-                case "Fujitsu FM Towns series":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "IBM PC Compatible (CD-Rom)":
-                    discType = "cd";
-                    processArguments = "/c2 20 /ns /sf /ss";
-                    break;
-                case "IBM PC Compatible (DVD-Rom)":
-                    discType = "dvd";
-                    processArguments = "";
-                    break;
-                case "NEC PC-88":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "NEC PC-98":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "Sharp X68000":
-                    // Placeholder for later use
-                    break;
-
-                #endregion
-
-                #region Arcade
-
-                case "Namco / Sega / Nintendo Triforce":
-                    // Placeholder for later use
-                    break;
-                case "Sega Chihiro":
-                    // Placeholder for later use
-                    break;
-                case "Sega Lindbergh":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "Sega Naomi":
-                    // Placeholder for later use
-                    break;
-                case "Sega Naomi 2":
-                    // Placeholder for later use
-                    break;
-                case "TAB-Austria Quizard":
-                    // Placeholder for later use
-                    break;
-                case "Tandy / Memorex Visual Information System":
-                    // Placeholder for later use
-                    break;
-
-                #endregion
-
-                #region Others
-
-                case "Audio CD":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "BD-Video":
-                    discType = "bd";
-                    processArguments = "";
-                    break;
-                case "DVD-Video":
-                    discType = "dvd";
-                    break;
-                case "PalmOS":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "Philips CD-i Digital Video":
-                    // Placeholder for later use
-                    break;
-                case "Photo CD":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "PlayStation GameShark Updates":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "Tao iKTV":
-                    // Placeholder for later use
-                    break;
-                case "Tomy Kiss-Site":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-                case "Video CD":
-                    discType = "cd";
-                    processArguments = "/c2 20";
-                    break;
-
-                #endregion
-
-                case "Unknown":
-                default:
-                    discType = "";
-                    processArguments = "";
-                    break;
-            }
+			// Get the discType and processArguments from a given system and disc combo
+			var selected = cmb_DiscType.SelectedValue as Tuple<string, KnownSystem?, DiscType?>;
+			string discType = Utilities.GetBaseCommand(selected.Item3);
+			string processArguments = string.Join(" ", Utilities.GetDefaultParameters(selected.Item2, selected.Item3));
 
             await Task.Run(
                 () =>
                 {
                     Process process = new Process();
-                    process.StartInfo.FileName = dicPath; // TODO: Make this configurable in UI
+                    process.StartInfo.FileName = dicPath;
                     process.StartInfo.Arguments = discType + " " + driveLetter + " \"" + outputDirectory + "\\" + outputFileName + "\" " + driveSpeed + " " + processArguments;
                     Console.WriteLine(process.StartInfo.Arguments);
                     process.Start();
                     process.WaitForExit();
                 });
 
-            if (isXboneOrPS4 == true)
-            {
-                // TODO: Add random string / GUID to end of batch file name so that multiple instances can run at once
-                using (StreamWriter writetext = new StreamWriter("XboneOrPS4.bat"))
-                {
-                    writetext.WriteLine("sg_raw.exe -v -r 4100 -R " + driveLetter + ": " + "ad 01 00 00 00 00 00 00 10 04 00 00 -o \"PIC.bin\"");
-                }
-                Process processXboneOrPS4 = new Process();
-                processXboneOrPS4.StartInfo.FileName = "XboneOrPS4.bat";
-                processXboneOrPS4.Start();
-                processXboneOrPS4.WaitForExit();
-            }
-            if (isPSX == true)
-            {
-                // TODO: Add random string / GUID to end of batch file name so that multiple instances can run at once
-                using (StreamWriter writetext = new StreamWriter("PSX.bat"))
-                {
-                    writetext.WriteLine("edccchk" + " " + "\"" + outputDirectory + "\\" + outputFileName + ".bin" + "\" > " + "\"" + outputDirectory + "\\" + "edccchk1.txt");
-                    writetext.WriteLine("edccchk" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 1).bin" + "\" > " + "\"" + outputDirectory + "\\" + "edccchk1.txt");
-                    writetext.WriteLine("edccchk" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 01).bin" + "\" > " + "\"" + outputDirectory + "\\" + "edccchk1.txt");
-                    writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + ".bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z1.txt");
-                    writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 1).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z2.txt");
-                    writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 01).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z3.txt");
-                    writetext.WriteLine("psxt001z" + " " + "--libcrypt " + "\"" + outputDirectory + "\\" + outputFileName + ".sub\" > " + "\"" + outputDirectory + "\\" + "libcrypt.txt");
-                    writetext.WriteLine("psxt001z" + " " + "--libcryptdrvfast " + driveLetter + " > " + "\"" + outputDirectory + "\\" + "libcryptdrv.log");
-                }
-                Process processpsx = new Process();
-                processpsx.StartInfo.FileName = "PSX.bat";
-                processpsx.Start();
-                processpsx.WaitForExit();
-            }
+			// Special cases
+			string guid = Guid.NewGuid().ToString();
+			switch (selected.Item2)
+			{
+				case KnownSystem.MicrosoftXBOXOne:
+				case KnownSystem.SonyPlayStation4:
+					// TODO: Direct invocation of program instead of via Batch File
+					using (StreamWriter writetext = new StreamWriter("XboneOrPS4" + guid + ".bat"))
+					{
+						writetext.WriteLine("sg_raw.exe -v -r 4100 -R " + driveLetter + ": " + "ad 01 00 00 00 00 00 00 10 04 00 00 -o \"PIC.bin\"");
+					}
+					Process processXboneOrPS4 = new Process();
+					processXboneOrPS4.StartInfo.FileName = "XboneOrPS4" + guid + ".bat";
+					processXboneOrPS4.Start();
+					processXboneOrPS4.WaitForExit();
+					break;
+				case KnownSystem.SonyPlayStation:
+					// TODO: Direct invocation of program instead of via Batch File
+					using (StreamWriter writetext = new StreamWriter("PSX" + guid + ".bat"))
+					{
+						writetext.WriteLine("edccchk" + " " + "\"" + outputDirectory + "\\" + outputFileName + ".bin" + "\" > " + "\"" + outputDirectory + "\\" + "edccchk1.txt");
+						writetext.WriteLine("edccchk" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 1).bin" + "\" > " + "\"" + outputDirectory + "\\" + "edccchk1.txt");
+						writetext.WriteLine("edccchk" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 01).bin" + "\" > " + "\"" + outputDirectory + "\\" + "edccchk1.txt");
+						writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + ".bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z1.txt");
+						writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 1).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z2.txt");
+						writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 01).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z3.txt");
+						writetext.WriteLine("psxt001z" + " " + "--libcrypt " + "\"" + outputDirectory + "\\" + outputFileName + ".sub\" > " + "\"" + outputDirectory + "\\" + "libcrypt.txt");
+						writetext.WriteLine("psxt001z" + " " + "--libcryptdrvfast " + driveLetter + " > " + "\"" + outputDirectory + "\\" + "libcryptdrv.log");
+					}
+					Process processpsx = new Process();
+					processpsx.StartInfo.FileName = "PSX" + guid + ".bat";
+					processpsx.Start();
+					processpsx.WaitForExit();
+					break;
+			}
+
             btn_Start.IsEnabled = true;
         }
 
         public MainWindow()
         {
             InitializeComponent();
+
+			// Populate the list of systems and add it to the combo box
+			_systems = Utilities.CreateListOfSystems();
+			cmb_DiscType.ItemsSource = _systems;
+			cmb_DiscType.DisplayMemberPath = "Item1";
+			cmb_DiscType.SelectedIndex = 0;
+
             ScanForDisk();
         }
 
@@ -361,16 +148,19 @@ namespace DICUI
             ScanForDisk();
         }
 
-
-
-        private void cmb_DiscType_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        private void cmb_DiscType_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-
+			// If we're on a separator, go to the next item
+			var tuple = cmb_DiscType.SelectedItem as Tuple<string, KnownSystem?, DiscType?>;
+			if (tuple.Item2 == null && tuple.Item3 == null)
+			{
+				cmb_DiscType.SelectedIndex++;
+			}
 
             lbl_Status.Content = "Ready to dump";
         }
 
-        private void cmb_DriveSpeed_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        private void cmb_DriveSpeed_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             // TODO: Figure out how to keep the list of items while also allowing the custom input
             if (cmb_DriveSpeed.SelectedIndex == 4)
@@ -384,7 +174,6 @@ namespace DICUI
         {
             switch (Convert.ToString(cmb_DiscType.Text))
             {
-
                 case "Sony PlayStation 4":
                     cmb_DriveSpeed.Items.Clear();
                     cmb_DriveSpeed.IsEnabled = false;

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -3,581 +3,581 @@ using System.Collections.Generic;
 
 namespace DICUI
 {
-	public static class Utilities
-	{
-		/// <summary>
-		/// Get the string representation of the DiscType enum values
-		/// </summary>
-		/// <param name="type">DiscType value to convert</param>
-		/// <returns>String representing the value, if possible</returns>
-		public static string DiscTypeToString(DiscType? type)
-		{
-			switch (type)
-			{
-				case DiscType.CD:
-					return "CD-ROM";
-				case DiscType.DVD5:
-					return "DVD-5 [Single-Layer]";
-				case DiscType.DVD9:
-					return "DVD-9 [Dual-Layer]";
-				case DiscType.GDROM:
-					return "GD-ROM";
-				case DiscType.HDDVD:
-					return "HD-DVD";
-				case DiscType.BD25:
-					return "BluRay-25 [Single-Layer]";
-				case DiscType.BD50:
-					return "BluRay-50 [Dual-Layer]";
+    public static class Utilities
+    {
+        /// <summary>
+        /// Get the string representation of the DiscType enum values
+        /// </summary>
+        /// <param name="type">DiscType value to convert</param>
+        /// <returns>String representing the value, if possible</returns>
+        public static string DiscTypeToString(DiscType? type)
+        {
+            switch (type)
+            {
+                case DiscType.CD:
+                    return "CD-ROM";
+                case DiscType.DVD5:
+                    return "DVD-5 [Single-Layer]";
+                case DiscType.DVD9:
+                    return "DVD-9 [Dual-Layer]";
+                case DiscType.GDROM:
+                    return "GD-ROM";
+                case DiscType.HDDVD:
+                    return "HD-DVD";
+                case DiscType.BD25:
+                    return "BluRay-25 [Single-Layer]";
+                case DiscType.BD50:
+                    return "BluRay-50 [Dual-Layer]";
 
-				case DiscType.GameCubeGameDisc:
-					return "GC Mini Disc";
-				case DiscType.UMD:
-					return "UMD";
+                case DiscType.GameCubeGameDisc:
+                    return "GameCube";
+                case DiscType.UMD:
+                    return "UMD";
 
-				case DiscType.Floppy:
-					return "Floppy Disk";
+                case DiscType.Floppy:
+                    return "Floppy Disk";
 
-				case DiscType.NONE:
-				default:
-					return "Unknown";
-			}
-		}
+                case DiscType.NONE:
+                default:
+                    return "Unknown";
+            }
+        }
 
-		/// <summary>
-		/// Get the string representation of the KnownSystem enum values
-		/// </summary>
-		/// <param name="sys">KnownSystem value to convert</param>
-		/// <returns>String representing the value, if possible</returns>
-		public static string KnownSystemToString(KnownSystem? sys)
-		{
-			switch (sys)
-			{
-				#region Consoles
+        /// <summary>
+        /// Get the string representation of the KnownSystem enum values
+        /// </summary>
+        /// <param name="sys">KnownSystem value to convert</param>
+        /// <returns>String representing the value, if possible</returns>
+        public static string KnownSystemToString(KnownSystem? sys)
+        {
+            switch (sys)
+            {
+                #region Consoles
 
-				case KnownSystem.BandaiPlaydiaQuickInteractiveSystem:
-					return "Bandai Playdia Quick Interactive System";
-				case KnownSystem.BandaiApplePippin:
-					return "Bandai / Apple Pippin";
-				case KnownSystem.CommodoreAmigaCD32:
-					return "Commodore Amiga CD32";
-				case KnownSystem.CommodoreAmigaCDTV:
-					return "Commodore Amiga CDTV";
-				case KnownSystem.MattelHyperscan:
-					return "Mattel HyperScan";
-				case KnownSystem.MicrosoftXBOX:
-					return "Microsoft XBOX";
-				case KnownSystem.MicrosoftXBOX360:
-					return "Microsoft XBOX 360";
-				case KnownSystem.MicrosoftXBOXOne:
-					return "Microsoft XBOX One";
-				case KnownSystem.NECPCEngineTurboGrafxCD:
-					return "NEC PC-Engine / TurboGrafx CD";
-				case KnownSystem.NECPCFX:
-					return "NEC PC-FX / PC-FXGA";
-				case KnownSystem.NintendoGameCube:
-					return "Nintendo GameCube";
-				case KnownSystem.NintendoWii:
-					return "Nintendo Wii";
-				case KnownSystem.NintendoWiiU:
-					return "Nintendo Wii U";
-				case KnownSystem.Panasonic3DOInteractiveMultiplayer:
-					return "Panasonic 3DO Interactive Multiplayer";
-				case KnownSystem.PhilipsCDi:
-					return "Philips CD-i";
-				case KnownSystem.SegaCDMegaCD:
-					return "Sega CD / Mega CD";
-				case KnownSystem.SegaDreamcast:
-					return "Sega Dreamcast";
-				case KnownSystem.SegaSaturn:
-					return "Sega Saturn";
-				case KnownSystem.SNKNeoGeoCD:
-					return "SNK Neo Geo CD";
-				case KnownSystem.SonyPlayStation:
-					return "Sony PlayStation";
-				case KnownSystem.SonyPlayStation2:
-					return "Sony PlayStation 2";
-				case KnownSystem.SonyPlayStation3:
-					return "Sony PlayStation 3";
-				case KnownSystem.SonyPlayStation4:
-					return "Sony PlayStation 4";
-				case KnownSystem.SonyPlayStationPortable:
-					return "Sony PlayStation Portable";
-				case KnownSystem.VMLabsNuon:
-					return "VM Labs NUON";
-				case KnownSystem.VTechVFlashVSmilePro:
-					return "VTech V.Flash - V.Smile Pro";
-				case KnownSystem.ZAPiTGamesGameWaveFamilyEntertainmentSystem:
-					return "ZAPiT Games Game Wave Family Entertainment System";
+                case KnownSystem.BandaiPlaydiaQuickInteractiveSystem:
+                    return "Bandai Playdia Quick Interactive System";
+                case KnownSystem.BandaiApplePippin:
+                    return "Bandai / Apple Pippin";
+                case KnownSystem.CommodoreAmigaCD32:
+                    return "Commodore Amiga CD32";
+                case KnownSystem.CommodoreAmigaCDTV:
+                    return "Commodore Amiga CDTV";
+                case KnownSystem.MattelHyperscan:
+                    return "Mattel HyperScan";
+                case KnownSystem.MicrosoftXBOX:
+                    return "Microsoft XBOX";
+                case KnownSystem.MicrosoftXBOX360:
+                    return "Microsoft XBOX 360";
+                case KnownSystem.MicrosoftXBOXOne:
+                    return "Microsoft XBOX One";
+                case KnownSystem.NECPCEngineTurboGrafxCD:
+                    return "NEC PC-Engine / TurboGrafx CD";
+                case KnownSystem.NECPCFX:
+                    return "NEC PC-FX / PC-FXGA";
+                case KnownSystem.NintendoGameCube:
+                    return "Nintendo GameCube";
+                case KnownSystem.NintendoWii:
+                    return "Nintendo Wii";
+                case KnownSystem.NintendoWiiU:
+                    return "Nintendo Wii U";
+                case KnownSystem.Panasonic3DOInteractiveMultiplayer:
+                    return "Panasonic 3DO Interactive Multiplayer";
+                case KnownSystem.PhilipsCDi:
+                    return "Philips CD-i";
+                case KnownSystem.SegaCDMegaCD:
+                    return "Sega CD / Mega CD";
+                case KnownSystem.SegaDreamcast:
+                    return "Sega Dreamcast";
+                case KnownSystem.SegaSaturn:
+                    return "Sega Saturn";
+                case KnownSystem.SNKNeoGeoCD:
+                    return "SNK Neo Geo CD";
+                case KnownSystem.SonyPlayStation:
+                    return "Sony PlayStation";
+                case KnownSystem.SonyPlayStation2:
+                    return "Sony PlayStation 2";
+                case KnownSystem.SonyPlayStation3:
+                    return "Sony PlayStation 3";
+                case KnownSystem.SonyPlayStation4:
+                    return "Sony PlayStation 4";
+                case KnownSystem.SonyPlayStationPortable:
+                    return "Sony PlayStation Portable";
+                case KnownSystem.VMLabsNuon:
+                    return "VM Labs NUON";
+                case KnownSystem.VTechVFlashVSmilePro:
+                    return "VTech V.Flash - V.Smile Pro";
+                case KnownSystem.ZAPiTGamesGameWaveFamilyEntertainmentSystem:
+                    return "ZAPiT Games Game Wave Family Entertainment System";
 
-				#endregion
+                #endregion
 
-				#region Computers
+                #region Computers
 
-				case KnownSystem.AcornArchimedes:
-					return "Acorn Archimedes";
-				case KnownSystem.AppleMacintosh:
-					return "Apple Macintosh";
-				case KnownSystem.CommodoreAmigaCD:
-					return "CommodoreAmigaCD";
-				case KnownSystem.FujitsuFMTowns:
-					return "Fujitsu FM Towns series";
-				case KnownSystem.IBMPCCompatible:
-					return "IBM PC Compatible";
-				case KnownSystem.NECPC88:
-					return "NEC PC-88";
-				case KnownSystem.NECPC98:
-					return "NEC PC-98";
-				case KnownSystem.SharpX68000:
-					return "Sharp X68000";
+                case KnownSystem.AcornArchimedes:
+                    return "Acorn Archimedes";
+                case KnownSystem.AppleMacintosh:
+                    return "Apple Macintosh";
+                case KnownSystem.CommodoreAmigaCD:
+                    return "CommodoreAmigaCD";
+                case KnownSystem.FujitsuFMTowns:
+                    return "Fujitsu FM Towns series";
+                case KnownSystem.IBMPCCompatible:
+                    return "IBM PC Compatible";
+                case KnownSystem.NECPC88:
+                    return "NEC PC-88";
+                case KnownSystem.NECPC98:
+                    return "NEC PC-98";
+                case KnownSystem.SharpX68000:
+                    return "Sharp X68000";
 
-				#endregion
+                #endregion
 
-				#region Arcade
+                #region Arcade
 
-				case KnownSystem.NamcoSegaNintendoTriforce:
-					return "Namco / Sega / Nintendo Triforce";
-				case KnownSystem.NamcoSystem246:
-					return "Namco System 246";
-				case KnownSystem.SegaChihiro:
-					return "Sega Chihiro";
-				case KnownSystem.SegaLindbergh:
-					return "Sega Lindbergh";
-				case KnownSystem.SegaNaomi:
-					return "Sega Naomi";
-				case KnownSystem.SegaNaomi2:
-					return "Sega Naomi 2";
-				case KnownSystem.TABAustriaQuizard:
-					return "TAB-Austria Quizard";
-				case KnownSystem.TandyMemorexVisualInformationSystem:
-					return "Tandy / Memorex Visual Information System";
+                case KnownSystem.NamcoSegaNintendoTriforce:
+                    return "Namco / Sega / Nintendo Triforce";
+                case KnownSystem.NamcoSystem246:
+                    return "Namco System 246";
+                case KnownSystem.SegaChihiro:
+                    return "Sega Chihiro";
+                case KnownSystem.SegaLindbergh:
+                    return "Sega Lindbergh";
+                case KnownSystem.SegaNaomi:
+                    return "Sega Naomi";
+                case KnownSystem.SegaNaomi2:
+                    return "Sega Naomi 2";
+                case KnownSystem.TABAustriaQuizard:
+                    return "TAB-Austria Quizard";
+                case KnownSystem.TandyMemorexVisualInformationSystem:
+                    return "Tandy / Memorex Visual Information System";
 
-				#endregion
+                #endregion
 
-				#region Others
+                #region Others
 
-				case KnownSystem.AudioCD:
-					return "Audio CD";
-				case KnownSystem.BDVideo:
-					return "BD-Video";
-				case KnownSystem.DVDVideo:
-					return "DVD-Video";
-				case KnownSystem.EnhancedCD:
-					return "Enhanced CD";
-				case KnownSystem.PalmOS:
-					return "PalmOS";
-				case KnownSystem.PhilipsCDiDigitalVideo:
-					return "Philips CD-i Digital Video";
-				case KnownSystem.PhotoCD:
-					return "Photo CD";
-				case KnownSystem.PlayStationGameSharkUpdates:
-					return "PlayStation GameShark Updates";
-				case KnownSystem.TaoiKTV:
-					return "Tao iKTV";
-				case KnownSystem.TomyKissSite:
-					return "Tomy Kiss-Site";
-				case KnownSystem.VideoCD:
-					return "Video CD";
+                case KnownSystem.AudioCD:
+                    return "Audio CD";
+                case KnownSystem.BDVideo:
+                    return "BD-Video";
+                case KnownSystem.DVDVideo:
+                    return "DVD-Video";
+                case KnownSystem.EnhancedCD:
+                    return "Enhanced CD";
+                case KnownSystem.PalmOS:
+                    return "PalmOS";
+                case KnownSystem.PhilipsCDiDigitalVideo:
+                    return "Philips CD-i Digital Video";
+                case KnownSystem.PhotoCD:
+                    return "Photo CD";
+                case KnownSystem.PlayStationGameSharkUpdates:
+                    return "PlayStation GameShark Updates";
+                case KnownSystem.TaoiKTV:
+                    return "Tao iKTV";
+                case KnownSystem.TomyKissSite:
+                    return "Tomy Kiss-Site";
+                case KnownSystem.VideoCD:
+                    return "Video CD";
 
-				#endregion
+                #endregion
 
-				case KnownSystem.NONE:
-				default:
-					return "Unknown";
-			}
-		}
+                case KnownSystem.NONE:
+                default:
+                    return "Unknown";
+            }
+        }
 
-		/// <summary>
-		/// Get a list of valid DiscTypes for a given system
-		/// </summary>
-		/// <param name="sys">KnownSystem value to check</param>
-		/// <returns>List of DiscTypes</returns>
-		public static List<DiscType?> GetValidDiscTypes(KnownSystem? sys)
-		{
-			List<DiscType?> types = new List<DiscType?>();
-			
-			switch (sys)
-			{
-				#region Consoles
+        /// <summary>
+        /// Get a list of valid DiscTypes for a given system
+        /// </summary>
+        /// <param name="sys">KnownSystem value to check</param>
+        /// <returns>List of DiscTypes</returns>
+        public static List<DiscType?> GetValidDiscTypes(KnownSystem? sys)
+        {
+            List<DiscType?> types = new List<DiscType?>();
+            
+            switch (sys)
+            {
+                #region Consoles
 
-				case KnownSystem.BandaiPlaydiaQuickInteractiveSystem:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.BandaiApplePippin:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.CommodoreAmigaCD32:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.CommodoreAmigaCDTV:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.MattelHyperscan:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.MicrosoftXBOX:
-					types.Add(DiscType.CD);
-					types.Add(DiscType.DVD5);
-					break;
-				case KnownSystem.MicrosoftXBOX360:
-					types.Add(DiscType.CD);
-					types.Add(DiscType.DVD9);
-					types.Add(DiscType.HDDVD);
-					break;
-				case KnownSystem.MicrosoftXBOXOne:
-					types.Add(DiscType.BD25);
-					types.Add(DiscType.BD50);
-					break;
-				case KnownSystem.NECPCEngineTurboGrafxCD:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.NECPCFX:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.NintendoGameCube:
-					types.Add(DiscType.GameCubeGameDisc);
-					break;
-				case KnownSystem.NintendoWii:
-					types.Add(DiscType.DVD5); // TODO: Confirm
-					types.Add(DiscType.DVD9); // TODO: Confirm
-					break;
-				case KnownSystem.NintendoWiiU:
-					types.Add(DiscType.DVD5); // TODO: Confirm
-					break;
-				case KnownSystem.Panasonic3DOInteractiveMultiplayer:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.PhilipsCDi:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.SegaCDMegaCD:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.SegaDreamcast:
-					types.Add(DiscType.GDROM);
-					break;
-				case KnownSystem.SegaSaturn:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.SNKNeoGeoCD:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.SonyPlayStation:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.SonyPlayStation2:
-					types.Add(DiscType.CD);
-					types.Add(DiscType.DVD5);
-					types.Add(DiscType.DVD9);
-					break;
-				case KnownSystem.SonyPlayStation3:
-					types.Add(DiscType.BD25);
-					types.Add(DiscType.BD50);
-					break;
-				case KnownSystem.SonyPlayStation4:
-					types.Add(DiscType.BD25);
-					types.Add(DiscType.BD50);
-					break;
-				case KnownSystem.SonyPlayStationPortable:
-					types.Add(DiscType.UMD);
-					break;
-				case KnownSystem.VMLabsNuon:
-					types.Add(DiscType.DVD5); // TODO: Confirm
-					break;
-				case KnownSystem.VTechVFlashVSmilePro:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.ZAPiTGamesGameWaveFamilyEntertainmentSystem:
-					types.Add(DiscType.DVD5);
-					break;
+                case KnownSystem.BandaiPlaydiaQuickInteractiveSystem:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.BandaiApplePippin:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.CommodoreAmigaCD32:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.CommodoreAmigaCDTV:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.MattelHyperscan:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.MicrosoftXBOX:
+                    types.Add(DiscType.CD);
+                    types.Add(DiscType.DVD5);
+                    break;
+                case KnownSystem.MicrosoftXBOX360:
+                    types.Add(DiscType.CD);
+                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.HDDVD);
+                    break;
+                case KnownSystem.MicrosoftXBOXOne:
+                    types.Add(DiscType.BD25);
+                    types.Add(DiscType.BD50);
+                    break;
+                case KnownSystem.NECPCEngineTurboGrafxCD:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.NECPCFX:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.NintendoGameCube:
+                    types.Add(DiscType.GameCubeGameDisc);
+                    break;
+                case KnownSystem.NintendoWii:
+                    types.Add(DiscType.DVD5); // TODO: Confirm
+                    types.Add(DiscType.DVD9); // TODO: Confirm
+                    break;
+                case KnownSystem.NintendoWiiU:
+                    types.Add(DiscType.DVD5); // TODO: Confirm
+                    break;
+                case KnownSystem.Panasonic3DOInteractiveMultiplayer:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.PhilipsCDi:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.SegaCDMegaCD:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.SegaDreamcast:
+                    types.Add(DiscType.GDROM);
+                    break;
+                case KnownSystem.SegaSaturn:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.SNKNeoGeoCD:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.SonyPlayStation:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.SonyPlayStation2:
+                    types.Add(DiscType.CD);
+                    types.Add(DiscType.DVD5);
+                    types.Add(DiscType.DVD9);
+                    break;
+                case KnownSystem.SonyPlayStation3:
+                    types.Add(DiscType.BD25);
+                    types.Add(DiscType.BD50);
+                    break;
+                case KnownSystem.SonyPlayStation4:
+                    types.Add(DiscType.BD25);
+                    types.Add(DiscType.BD50);
+                    break;
+                case KnownSystem.SonyPlayStationPortable:
+                    types.Add(DiscType.UMD);
+                    break;
+                case KnownSystem.VMLabsNuon:
+                    types.Add(DiscType.DVD5); // TODO: Confirm
+                    break;
+                case KnownSystem.VTechVFlashVSmilePro:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.ZAPiTGamesGameWaveFamilyEntertainmentSystem:
+                    types.Add(DiscType.DVD5);
+                    break;
 
-				#endregion
+                #endregion
 
-				#region Computers
+                #region Computers
 
-				case KnownSystem.AcornArchimedes:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.AppleMacintosh:
-					types.Add(DiscType.CD);
-					types.Add(DiscType.DVD5);
-					types.Add(DiscType.DVD9);
-					types.Add(DiscType.Floppy);
-					break;
-				case KnownSystem.CommodoreAmigaCD:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.FujitsuFMTowns:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.IBMPCCompatible:
-					types.Add(DiscType.CD);
-					types.Add(DiscType.DVD5);
-					types.Add(DiscType.DVD9);
-					types.Add(DiscType.Floppy);
-					break;
-				case KnownSystem.NECPC88:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.NECPC98:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.SharpX68000:
-					types.Add(DiscType.CD);
-					break;
+                case KnownSystem.AcornArchimedes:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.AppleMacintosh:
+                    types.Add(DiscType.CD);
+                    types.Add(DiscType.DVD5);
+                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.Floppy);
+                    break;
+                case KnownSystem.CommodoreAmigaCD:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.FujitsuFMTowns:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.IBMPCCompatible:
+                    types.Add(DiscType.CD);
+                    types.Add(DiscType.DVD5);
+                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.Floppy);
+                    break;
+                case KnownSystem.NECPC88:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.NECPC98:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.SharpX68000:
+                    types.Add(DiscType.CD);
+                    break;
 
-				#endregion
+                #endregion
 
-				#region Arcade
+                #region Arcade
 
-				case KnownSystem.NamcoSegaNintendoTriforce:
-					types.Add(DiscType.GDROM);
-					break;
-				case KnownSystem.SegaChihiro:
-					types.Add(DiscType.GDROM);
-					break;
-				case KnownSystem.SegaLindbergh:
-					types.Add(DiscType.DVD5); // TODO: Confirm
-					break;
-				case KnownSystem.SegaNaomi:
-					types.Add(DiscType.GDROM);
-					break;
-				case KnownSystem.SegaNaomi2:
-					types.Add(DiscType.GDROM);
-					break;
-				case KnownSystem.TABAustriaQuizard:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.TandyMemorexVisualInformationSystem:
-					types.Add(DiscType.CD);
-					break;
+                case KnownSystem.NamcoSegaNintendoTriforce:
+                    types.Add(DiscType.GDROM);
+                    break;
+                case KnownSystem.SegaChihiro:
+                    types.Add(DiscType.GDROM);
+                    break;
+                case KnownSystem.SegaLindbergh:
+                    types.Add(DiscType.DVD5); // TODO: Confirm
+                    break;
+                case KnownSystem.SegaNaomi:
+                    types.Add(DiscType.GDROM);
+                    break;
+                case KnownSystem.SegaNaomi2:
+                    types.Add(DiscType.GDROM);
+                    break;
+                case KnownSystem.TABAustriaQuizard:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.TandyMemorexVisualInformationSystem:
+                    types.Add(DiscType.CD);
+                    break;
 
-				#endregion
+                #endregion
 
-				#region Others
+                #region Others
 
-				case KnownSystem.AudioCD:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.BDVideo:
-					types.Add(DiscType.BD25);
-					types.Add(DiscType.BD50);
-					break;
-				case KnownSystem.DVDVideo:
-					types.Add(DiscType.DVD5);
-					types.Add(DiscType.DVD9);
-					break;
-				case KnownSystem.EnhancedCD:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.PalmOS:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.PhilipsCDiDigitalVideo:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.PhotoCD:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.PlayStationGameSharkUpdates:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.TaoiKTV:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.TomyKissSite:
-					types.Add(DiscType.CD);
-					break;
-				case KnownSystem.VideoCD:
-					types.Add(DiscType.CD);
-					break;
+                case KnownSystem.AudioCD:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.BDVideo:
+                    types.Add(DiscType.BD25);
+                    types.Add(DiscType.BD50);
+                    break;
+                case KnownSystem.DVDVideo:
+                    types.Add(DiscType.DVD5);
+                    types.Add(DiscType.DVD9);
+                    break;
+                case KnownSystem.EnhancedCD:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.PalmOS:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.PhilipsCDiDigitalVideo:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.PhotoCD:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.PlayStationGameSharkUpdates:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.TaoiKTV:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.TomyKissSite:
+                    types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.VideoCD:
+                    types.Add(DiscType.CD);
+                    break;
 
-				#endregion
+                #endregion
 
-				case KnownSystem.NONE:
-				default:
-					types.Add(DiscType.NONE);
-					break;
-			}
+                case KnownSystem.NONE:
+                default:
+                    types.Add(DiscType.NONE);
+                    break;
+            }
 
-			return types;
-		}
+            return types;
+        }
 
-		/// <summary>
-		/// Get the DIC command to be used for a given DiscType
-		/// </summary>
-		/// <param name="type">DiscType value to check</param>
-		/// <returns>String containing the command, null on error</returns>
-		public static string GetBaseCommand(DiscType? type)
-		{
-			switch (type)
-			{
-				case DiscType.CD:
-					return "cd";
-				case DiscType.DVD5:
-					return "dvd";
-				case DiscType.DVD9:
-					return "dvd";
-				case DiscType.GDROM:
-					return "gd"; // TODO: "swap"?
-				case DiscType.HDDVD:
-					Console.WriteLine("HD-DVD dumping is not supported by DIC");
-					return null;
-				case DiscType.BD25:
-					return "bd";
-				case DiscType.BD50:
-					return "bd";
+        /// <summary>
+        /// Get the DIC command to be used for a given DiscType
+        /// </summary>
+        /// <param name="type">DiscType value to check</param>
+        /// <returns>String containing the command, null on error</returns>
+        public static string GetBaseCommand(DiscType? type)
+        {
+            switch (type)
+            {
+                case DiscType.CD:
+                    return "cd";
+                case DiscType.DVD5:
+                    return "dvd";
+                case DiscType.DVD9:
+                    return "dvd";
+                case DiscType.GDROM:
+                    return "gd"; // TODO: "swap"?
+                case DiscType.HDDVD:
+                    Console.WriteLine("HD-DVD dumping is not supported by DIC");
+                    return null;
+                case DiscType.BD25:
+                    return "bd";
+                case DiscType.BD50:
+                    return "bd";
 
-				// Special Formats
-				case DiscType.GameCubeGameDisc:
-					return "dvd";
-				case DiscType.UMD:
-					Console.WriteLine("UMD dumping is not supported by DIC");
-					return null;
+                // Special Formats
+                case DiscType.GameCubeGameDisc:
+                    return "dvd";
+                case DiscType.UMD:
+                    Console.WriteLine("UMD dumping is not supported by DIC");
+                    return null;
 
-				// Non-optical
-				case DiscType.Floppy:
-					return "fd";
+                // Non-optical
+                case DiscType.Floppy:
+                    return "fd";
 
-				default:
-					return null;
-			}
-		}
+                default:
+                    return null;
+            }
+        }
 
-		/// <summary>
-		/// Get list of default parameters for a given system and disc type
-		/// </summary>
-		/// <param name="sys">KnownSystem value to check</param>
-		/// <param name="type">DiscType value to check</param>
-		/// <returns>List of strings representing the parameters</returns>
-		public static List<string> GetDefaultParameters(KnownSystem? sys, DiscType? type)
-		{
-			// First check to see if the combination of system and disctype is valid
-			List<DiscType?> validTypes = GetValidDiscTypes(sys);
-			if (!validTypes.Contains(type))
-			{
-				Console.WriteLine("Invalid DiscType '{0}' for System '{1}'", type.ToString(), KnownSystemToString(sys));
-				return null;
-			}
+        /// <summary>
+        /// Get list of default parameters for a given system and disc type
+        /// </summary>
+        /// <param name="sys">KnownSystem value to check</param>
+        /// <param name="type">DiscType value to check</param>
+        /// <returns>List of strings representing the parameters</returns>
+        public static List<string> GetDefaultParameters(KnownSystem? sys, DiscType? type)
+        {
+            // First check to see if the combination of system and disctype is valid
+            List<DiscType?> validTypes = GetValidDiscTypes(sys);
+            if (!validTypes.Contains(type))
+            {
+                Console.WriteLine("Invalid DiscType '{0}' for System '{1}'", type.ToString(), KnownSystemToString(sys));
+                return null;
+            }
 
-			// Now sort based on disc type
-			List<string> parameters = new List<string>();
-			switch (type)
-			{
-				case DiscType.CD:
-					parameters.Add("/c2 20");
+            // Now sort based on disc type
+            List<string> parameters = new List<string>();
+            switch (type)
+            {
+                case DiscType.CD:
+                    parameters.Add("/c2 20");
 
-					switch (sys)
-					{
-						case KnownSystem.AppleMacintosh:
-						case KnownSystem.IBMPCCompatible:
-							parameters.Add("/ns");
-							parameters.Add("/sf");
-							parameters.Add("/ss");
-							break;
-						case KnownSystem.NECPCEngineTurboGrafxCD:
-							parameters.Add("/m");
-							break;
-						case KnownSystem.SonyPlayStation:
-							parameters.Add("/am");
-							break;
-					}
-					break;
-				case DiscType.DVD5:
-					// Currently no defaults set
-					break;
-				case DiscType.DVD9:
-					// Currently no defaults set
-					break;
-				case DiscType.GDROM:
-					parameters.Add("/c2 20");
-					break;
-				case DiscType.HDDVD:
-					Console.WriteLine("HD-DVD dumping is not supported by DIC");
-					break;
-				case DiscType.BD25:
-					// Currently no defaults set
-					break;
-				case DiscType.BD50:
-					// Currently no defaults set
-					break;
+                    switch (sys)
+                    {
+                        case KnownSystem.AppleMacintosh:
+                        case KnownSystem.IBMPCCompatible:
+                            parameters.Add("/ns");
+                            parameters.Add("/sf");
+                            parameters.Add("/ss");
+                            break;
+                        case KnownSystem.NECPCEngineTurboGrafxCD:
+                            parameters.Add("/m");
+                            break;
+                        case KnownSystem.SonyPlayStation:
+                            parameters.Add("/am");
+                            break;
+                    }
+                    break;
+                case DiscType.DVD5:
+                    // Currently no defaults set
+                    break;
+                case DiscType.DVD9:
+                    // Currently no defaults set
+                    break;
+                case DiscType.GDROM:
+                    parameters.Add("/c2 20");
+                    break;
+                case DiscType.HDDVD:
+                    Console.WriteLine("HD-DVD dumping is not supported by DIC");
+                    break;
+                case DiscType.BD25:
+                    // Currently no defaults set
+                    break;
+                case DiscType.BD50:
+                    // Currently no defaults set
+                    break;
 
-				// Special Formats
-				case DiscType.GameCubeGameDisc:
-					parameters.Add("/raw");
-					break;
-				case DiscType.UMD:
-					Console.WriteLine("UMD dumping is not supported by DIC");
-					break;
+                // Special Formats
+                case DiscType.GameCubeGameDisc:
+                    parameters.Add("/raw");
+                    break;
+                case DiscType.UMD:
+                    Console.WriteLine("UMD dumping is not supported by DIC");
+                    break;
 
-				// Non-optical
-				case DiscType.Floppy:
-					// Currently no defaults set
-					break;
-			}
+                // Non-optical
+                case DiscType.Floppy:
+                    // Currently no defaults set
+                    break;
+            }
 
-			return parameters;
-		}
+            return parameters;
+        }
 
-		/// <summary>
-		/// Create a list of systems matched to their respective enums
-		/// </summary>
-		/// <returns></returns>
-		/// <remarks>
-		/// This returns a List of Tuples whose structure is as follows:
-		///		Item 1: Printable name
-		///		Item 2: KnownSystem mapping
-		///		Item 3: DiscType mapping
-		///	If something has a "string, null, null" value, it should be assumed that it is a separator
-		/// </remarks>
-		public static List<Tuple<string, KnownSystem?, DiscType?>> CreateListOfSystems()
-		{
-			List<Tuple<string, KnownSystem?, DiscType?>> mapping = new List<Tuple<string, KnownSystem?, DiscType?>>();
+        /// <summary>
+        /// Create a list of systems matched to their respective enums
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>
+        /// This returns a List of Tuples whose structure is as follows:
+        ///		Item 1: Printable name
+        ///		Item 2: KnownSystem mapping
+        ///		Item 3: DiscType mapping
+        ///	If something has a "string, null, null" value, it should be assumed that it is a separator
+        /// </remarks>
+        public static List<Tuple<string, KnownSystem?, DiscType?>> CreateListOfSystems()
+        {
+            List<Tuple<string, KnownSystem?, DiscType?>> mapping = new List<Tuple<string, KnownSystem?, DiscType?>>();
 
-			foreach (KnownSystem system in Enum.GetValues(typeof(KnownSystem)))
-			{
-				// In the special cases of breaks, we want to add the proper mappings for sections
-				switch (system)
-				{
-					// Consoles section
-					case KnownSystem.BandaiPlaydiaQuickInteractiveSystem:
-						mapping.Add(new Tuple<string, KnownSystem?, DiscType?>("---------- Consoles ----------", null, null));
-						break;
+            foreach (KnownSystem system in Enum.GetValues(typeof(KnownSystem)))
+            {
+                // In the special cases of breaks, we want to add the proper mappings for sections
+                switch (system)
+                {
+                    // Consoles section
+                    case KnownSystem.BandaiPlaydiaQuickInteractiveSystem:
+                        mapping.Add(new Tuple<string, KnownSystem?, DiscType?>("---------- Consoles ----------", null, null));
+                        break;
 
-					// Computers section
-					case KnownSystem.AcornArchimedes:
-						mapping.Add(new Tuple<string, KnownSystem?, DiscType?>("---------- Computers ----------", null, null));
-						break;
+                    // Computers section
+                    case KnownSystem.AcornArchimedes:
+                        mapping.Add(new Tuple<string, KnownSystem?, DiscType?>("---------- Computers ----------", null, null));
+                        break;
 
-					// Arcade section
-					case KnownSystem.NamcoSegaNintendoTriforce:
-						mapping.Add(new Tuple<string, KnownSystem?, DiscType?>("---------- Arcade ----------", null, null));
-						break;
+                    // Arcade section
+                    case KnownSystem.NamcoSegaNintendoTriforce:
+                        mapping.Add(new Tuple<string, KnownSystem?, DiscType?>("---------- Arcade ----------", null, null));
+                        break;
 
-					// Other section
-					case KnownSystem.AudioCD:
-						mapping.Add(new Tuple<string, KnownSystem?, DiscType?>("---------- Others ----------", null, null));
-						break;
-				}
+                    // Other section
+                    case KnownSystem.AudioCD:
+                        mapping.Add(new Tuple<string, KnownSystem?, DiscType?>("---------- Others ----------", null, null));
+                        break;
+                }
 
-				// First, get a list of all DiscTypes for a given KnownSystem
-				List<DiscType?> types = GetValidDiscTypes(system);
+                // First, get a list of all DiscTypes for a given KnownSystem
+                List<DiscType?> types = GetValidDiscTypes(system);
 
-				// If we have a single type, we don't want to postfix the system name with it
-				if (types.Count == 1)
-				{
-					mapping.Add(new Tuple<string, KnownSystem?, DiscType?>(KnownSystemToString(system), system, types[0]));
-				}
-				// Otherwise, postfix the system name properly
-				else
-				{
-					foreach (DiscType type in types)
-					{
-						mapping.Add(new Tuple<string, KnownSystem?, DiscType?>(KnownSystemToString(system) + " (" + DiscTypeToString(type) + ")", system, type));
-					}
-				}
-			}
+                // If we have a single type, we don't want to postfix the system name with it
+                if (types.Count == 1)
+                {
+                    mapping.Add(new Tuple<string, KnownSystem?, DiscType?>(KnownSystemToString(system), system, types[0]));
+                }
+                // Otherwise, postfix the system name properly
+                else
+                {
+                    foreach (DiscType type in types)
+                    {
+                        mapping.Add(new Tuple<string, KnownSystem?, DiscType?>(KnownSystemToString(system) + " (" + DiscTypeToString(type) + ")", system, type));
+                    }
+                }
+            }
 
-			return mapping;
-		}
-	}
+            return mapping;
+        }
+    }
 }

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -6,11 +6,49 @@ namespace DICUI
 	public static class Utilities
 	{
 		/// <summary>
-		/// Get the string representation of the System enum values
+		/// Get the string representation of the DiscType enum values
 		/// </summary>
-		/// <param name="sys">System value to convert</param>
+		/// <param name="type">DiscType value to convert</param>
 		/// <returns>String representing the value, if possible</returns>
-		public static string SystemToString(KnownSystem sys)
+		public static string DiscTypeToString(DiscType type)
+		{
+			switch (type)
+			{
+				case DiscType.CD:
+					return "CD-ROM";
+				case DiscType.DVD5:
+					return "DVD-5 [Single-Layer]";
+				case DiscType.DVD9:
+					return "DVD-9 [Dual-Layer]";
+				case DiscType.GDROM:
+					return "GD-ROM";
+				case DiscType.HDDVD:
+					return "HD-DVD";
+				case DiscType.BD25:
+					return "BluRay-25 [Single-Layer]";
+				case DiscType.BD50:
+					return "BluRay-50 [Dual-Layer]";
+
+				case DiscType.GameCubeGameDisc:
+					return "GC Mini Disc";
+				case DiscType.UMD:
+					return "UMD";
+
+				case DiscType.Floppy:
+					return "Floppy Disk";
+
+				case DiscType.NONE:
+				default:
+					return "Unknown";
+			}
+		}
+
+		/// <summary>
+		/// Get the string representation of the KnownSystem enum values
+		/// </summary>
+		/// <param name="sys">KnownSystem value to convert</param>
+		/// <returns>String representing the value, if possible</returns>
+		public static string KnownSystemToString(KnownSystem sys)
 		{
 			switch (sys)
 			{
@@ -151,7 +189,7 @@ namespace DICUI
 		/// <summary>
 		/// Get a list of valid DiscTypes for a given system
 		/// </summary>
-		/// <param name="sys">System value to check</param>
+		/// <param name="sys">KnownSystem value to check</param>
 		/// <returns>List of DiscTypes</returns>
 		public static List<DiscType> GetValidDiscTypes(KnownSystem sys)
 		{
@@ -408,7 +446,7 @@ namespace DICUI
 		/// <summary>
 		/// Get list of default parameters for a given system and disc type
 		/// </summary>
-		/// <param name="sys">System value to check</param>
+		/// <param name="sys">KnownSystem value to check</param>
 		/// <param name="type">DiscType value to check</param>
 		/// <returns>List of strings representing the parameters</returns>
 		public static List<string> GetDefaultParameters(KnownSystem sys, DiscType type)
@@ -417,7 +455,7 @@ namespace DICUI
 			List<DiscType> validTypes = GetValidDiscTypes(sys);
 			if (!validTypes.Contains(type))
 			{
-				Console.WriteLine("Invalid DiscType '{0}' for System '{1}'", type.ToString(), SystemToString(sys));
+				Console.WriteLine("Invalid DiscType '{0}' for System '{1}'", type.ToString(), KnownSystemToString(sys));
 				return null;
 			}
 

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -10,7 +10,7 @@ namespace DICUI
 		/// </summary>
 		/// <param name="type">DiscType value to convert</param>
 		/// <returns>String representing the value, if possible</returns>
-		public static string DiscTypeToString(DiscType type)
+		public static string DiscTypeToString(DiscType? type)
 		{
 			switch (type)
 			{
@@ -48,7 +48,7 @@ namespace DICUI
 		/// </summary>
 		/// <param name="sys">KnownSystem value to convert</param>
 		/// <returns>String representing the value, if possible</returns>
-		public static string KnownSystemToString(KnownSystem sys)
+		public static string KnownSystemToString(KnownSystem? sys)
 		{
 			switch (sys)
 			{
@@ -191,9 +191,9 @@ namespace DICUI
 		/// </summary>
 		/// <param name="sys">KnownSystem value to check</param>
 		/// <returns>List of DiscTypes</returns>
-		public static List<DiscType> GetValidDiscTypes(KnownSystem sys)
+		public static List<DiscType?> GetValidDiscTypes(KnownSystem? sys)
 		{
-			List<DiscType> types = new List<DiscType>();
+			List<DiscType?> types = new List<DiscType?>();
 			
 			switch (sys)
 			{
@@ -407,7 +407,7 @@ namespace DICUI
 		/// </summary>
 		/// <param name="type">DiscType value to check</param>
 		/// <returns>String containing the command, null on error</returns>
-		public static string GetBaseCommand(DiscType type)
+		public static string GetBaseCommand(DiscType? type)
 		{
 			switch (type)
 			{
@@ -449,10 +449,10 @@ namespace DICUI
 		/// <param name="sys">KnownSystem value to check</param>
 		/// <param name="type">DiscType value to check</param>
 		/// <returns>List of strings representing the parameters</returns>
-		public static List<string> GetDefaultParameters(KnownSystem sys, DiscType type)
+		public static List<string> GetDefaultParameters(KnownSystem? sys, DiscType? type)
 		{
 			// First check to see if the combination of system and disctype is valid
-			List<DiscType> validTypes = GetValidDiscTypes(sys);
+			List<DiscType?> validTypes = GetValidDiscTypes(sys);
 			if (!validTypes.Contains(type))
 			{
 				Console.WriteLine("Invalid DiscType '{0}' for System '{1}'", type.ToString(), KnownSystemToString(sys));
@@ -560,7 +560,7 @@ namespace DICUI
 				}
 
 				// First, get a list of all DiscTypes for a given KnownSystem
-				List<DiscType> types = GetValidDiscTypes(system);
+				List<DiscType?> types = GetValidDiscTypes(system);
 
 				// If we have a single type, we don't want to postfix the system name with it
 				if (types.Count == 1)

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -517,5 +517,67 @@ namespace DICUI
 
 			return parameters;
 		}
+
+		/// <summary>
+		/// Create a list of systems matched to their respective enums
+		/// </summary>
+		/// <returns></returns>
+		/// <remarks>
+		/// This returns a List of Tuples whose structure is as follows:
+		///		Item 1: Printable name
+		///		Item 2: KnownSystem mapping
+		///		Item 3: DiscType mapping
+		///	If something has a "string, null, null" value, it should be assumed that it is a separator
+		/// </remarks>
+		public static List<Tuple<string, KnownSystem?, DiscType?>> CreateListOfSystems()
+		{
+			List<Tuple<string, KnownSystem?, DiscType?>> mapping = new List<Tuple<string, KnownSystem?, DiscType?>>();
+
+			foreach (KnownSystem system in Enum.GetValues(typeof(KnownSystem)))
+			{
+				// In the special cases of breaks, we want to add the proper mappings for sections
+				switch (system)
+				{
+					// Consoles section
+					case KnownSystem.BandaiPlaydiaQuickInteractiveSystem:
+						mapping.Add(new Tuple<string, KnownSystem?, DiscType?>("---------- Consoles ----------", null, null));
+						break;
+
+					// Computers section
+					case KnownSystem.AcornArchimedes:
+						mapping.Add(new Tuple<string, KnownSystem?, DiscType?>("---------- Computers ----------", null, null));
+						break;
+
+					// Arcade section
+					case KnownSystem.NamcoSegaNintendoTriforce:
+						mapping.Add(new Tuple<string, KnownSystem?, DiscType?>("---------- Arcade ----------", null, null));
+						break;
+
+					// Other section
+					case KnownSystem.AudioCD:
+						mapping.Add(new Tuple<string, KnownSystem?, DiscType?>("---------- Others ----------", null, null));
+						break;
+				}
+
+				// First, get a list of all DiscTypes for a given KnownSystem
+				List<DiscType> types = GetValidDiscTypes(system);
+
+				// If we have a single type, we don't want to postfix the system name with it
+				if (types.Count == 0)
+				{
+					mapping.Add(new Tuple<string, KnownSystem?, DiscType?>(KnownSystemToString(system), system, types[0]));
+				}
+				// Otherwise, postfix the system name properly
+				else
+				{
+					foreach (DiscType type in types)
+					{
+						mapping.Add(new Tuple<string, KnownSystem?, DiscType?>(KnownSystemToString(system) + "(" + DiscTypeToString(type) + ")", system, type));
+					}
+				}
+			}
+
+			return mapping;
+		}
 	}
 }

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -118,7 +118,7 @@ namespace DICUI
                 case KnownSystem.AppleMacintosh:
                     return "Apple Macintosh";
                 case KnownSystem.CommodoreAmigaCD:
-                    return "CommodoreAmigaCD";
+                    return "Commodore Amiga CD";
                 case KnownSystem.FujitsuFMTowns:
                     return "Fujitsu FM Towns series";
                 case KnownSystem.IBMPCCompatible:

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -563,7 +563,7 @@ namespace DICUI
 				List<DiscType> types = GetValidDiscTypes(system);
 
 				// If we have a single type, we don't want to postfix the system name with it
-				if (types.Count == 0)
+				if (types.Count == 1)
 				{
 					mapping.Add(new Tuple<string, KnownSystem?, DiscType?>(KnownSystemToString(system), system, types[0]));
 				}
@@ -572,7 +572,7 @@ namespace DICUI
 				{
 					foreach (DiscType type in types)
 					{
-						mapping.Add(new Tuple<string, KnownSystem?, DiscType?>(KnownSystemToString(system) + "(" + DiscTypeToString(type) + ")", system, type));
+						mapping.Add(new Tuple<string, KnownSystem?, DiscType?>(KnownSystemToString(system) + " (" + DiscTypeToString(type) + ")", system, type));
 					}
 				}
 			}

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -1,0 +1,483 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DICUI
+{
+	public static class Utilities
+	{
+		/// <summary>
+		/// Get the string representation of the System enum values
+		/// </summary>
+		/// <param name="sys">System value to convert</param>
+		/// <returns>String representing the value, if possible</returns>
+		public static string SystemToString(System sys)
+		{
+			switch (sys)
+			{
+				#region Consoles
+
+				case System.BandaiPlaydiaQuickInteractiveSystem:
+					return "Bandai Playdia Quick Interactive System";
+				case System.BandaiApplePippin:
+					return "Bandai / Apple Pippin";
+				case System.CommodoreAmigaCD32:
+					return "Commodore Amiga CD32";
+				case System.CommodoreAmigaCDTV:
+					return "Commodore Amiga CDTV";
+				case System.MattelHyperscan:
+					return "Mattel HyperScan";
+				case System.MicrosoftXBOX:
+					return "Microsoft XBOX";
+				case System.MicrosoftXBOX360:
+					return "Microsoft XBOX 360";
+				case System.MicrosoftXBOXOne:
+					return "Microsoft XBOX One";
+				case System.NECPCEngineTurboGrafxCD:
+					return "NEC PC-Engine / TurboGrafx CD";
+				case System.NECPCFX:
+					return "NEC PC-FX / PC-FXGA";
+				case System.NintendoGameCube:
+					return "Nintendo GameCube";
+				case System.NintendoWii:
+					return "Nintendo Wii";
+				case System.NintendoWiiU:
+					return "Nintendo Wii U";
+				case System.Panasonic3DOInteractiveMultiplayer:
+					return "Panasonic 3DO Interactive Multiplayer";
+				case System.PhilipsCDi:
+					return "Philips CD-i";
+				case System.SegaCDMegaCD:
+					return "Sega CD / Mega CD";
+				case System.SegaDreamcast:
+					return "Sega Dreamcast";
+				case System.SegaSaturn:
+					return "Sega Saturn";
+				case System.SNKNeoGeoCD:
+					return "SNK Neo Geo CD";
+				case System.SonyPlayStation:
+					return "Sony PlayStation";
+				case System.SonyPlayStation2:
+					return "Sony PlayStation 2";
+				case System.SonyPlayStation3:
+					return "Sony PlayStation 3";
+				case System.SonyPlayStation4:
+					return "Sony PlayStation 4";
+				case System.SonyPlayStationPortable:
+					return "Sony PlayStation Portable";
+				case System.VMLabsNuon:
+					return "VM Labs NUON";
+				case System.VTechVFlashVSmilePro:
+					return "VTech V.Flash - V.Smile Pro";
+				case System.ZAPiTGamesGameWaveFamilyEntertainmentSystem:
+					return "ZAPiT Games Game Wave Family Entertainment System";
+
+				#endregion
+
+				#region Computers
+
+				case System.AcornArchimedes:
+					return "Acorn Archimedes";
+				case System.AppleMacintosh:
+					return "Apple Macintosh";
+				case System.CommodoreAmigaCD:
+					return "CommodoreAmigaCD";
+				case System.FujitsuFMTowns:
+					return "Fujitsu FM Towns series";
+				case System.IBMPCCompatible:
+					return "IBM PC Compatible";
+				case System.NECPC88:
+					return "NEC PC-88";
+				case System.NECPC98:
+					return "NEC PC-98";
+				case System.SharpX68000:
+					return "Sharp X68000";
+
+				#endregion
+
+				#region Arcade
+
+				case System.NamcoSegaNintendoTriforce:
+					return "Namco / Sega / Nintendo Triforce";
+				case System.NamcoSystem246:
+					return "Namco System 246";
+				case System.SegaChihiro:
+					return "Sega Chihiro";
+				case System.SegaLindbergh:
+					return "Sega Lindbergh";
+				case System.SegaNaomi:
+					return "Sega Naomi";
+				case System.SegaNaomi2:
+					return "Sega Naomi 2";
+				case System.TABAustriaQuizard:
+					return "TAB-Austria Quizard";
+				case System.TandyMemorexVisualInformationSystem:
+					return "Tandy / Memorex Visual Information System";
+
+				#endregion
+
+				#region Others
+
+				case System.AudioCD:
+					return "Audio CD";
+				case System.BDVideo:
+					return "BD-Video";
+				case System.DVDVideo:
+					return "DVD-Video";
+				case System.EnhancedCD:
+					return "Enhanced CD";
+				case System.PalmOS:
+					return "PalmOS";
+				case System.PhilipsCDiDigitalVideo:
+					return "Philips CD-i Digital Video";
+				case System.PhotoCD:
+					return "Photo CD";
+				case System.PlayStationGameSharkUpdates:
+					return "PlayStation GameShark Updates";
+				case System.TaoiKTV:
+					return "Tao iKTV";
+				case System.TomyKissSite:
+					return "Tomy Kiss-Site";
+				case System.VideoCD:
+					return "Video CD";
+
+				#endregion
+
+				case System.NONE:
+				default:
+					return "Unknown";
+			}
+		}
+
+		/// <summary>
+		/// Get a list of valid DiscTypes for a given system
+		/// </summary>
+		/// <param name="sys">System value to check</param>
+		/// <returns>List of DiscTypes</returns>
+		public static List<DiscType> GetValidDiscTypes(System sys)
+		{
+			List<DiscType> types = new List<DiscType>();
+			
+			switch (sys)
+			{
+				#region Consoles
+
+				case System.BandaiPlaydiaQuickInteractiveSystem:
+					types.Add(DiscType.CD);
+					break;
+				case System.BandaiApplePippin:
+					types.Add(DiscType.CD);
+					break;
+				case System.CommodoreAmigaCD32:
+					types.Add(DiscType.CD);
+					break;
+				case System.CommodoreAmigaCDTV:
+					types.Add(DiscType.CD);
+					break;
+				case System.MattelHyperscan:
+					types.Add(DiscType.CD);
+					break;
+				case System.MicrosoftXBOX:
+					types.Add(DiscType.CD);
+					types.Add(DiscType.DVD5);
+					break;
+				case System.MicrosoftXBOX360:
+					types.Add(DiscType.CD);
+					types.Add(DiscType.DVD9);
+					types.Add(DiscType.HDDVD);
+					break;
+				case System.MicrosoftXBOXOne:
+					types.Add(DiscType.BD25);
+					types.Add(DiscType.BD50);
+					break;
+				case System.NECPCEngineTurboGrafxCD:
+					types.Add(DiscType.CD);
+					break;
+				case System.NECPCFX:
+					types.Add(DiscType.CD);
+					break;
+				case System.NintendoGameCube:
+					types.Add(DiscType.GameCubeGameDisc);
+					break;
+				case System.NintendoWii:
+					types.Add(DiscType.DVD5); // TODO: Confirm
+					types.Add(DiscType.DVD9); // TODO: Confirm
+					break;
+				case System.NintendoWiiU:
+					types.Add(DiscType.DVD5); // TODO: Confirm
+					break;
+				case System.Panasonic3DOInteractiveMultiplayer:
+					types.Add(DiscType.CD);
+					break;
+				case System.PhilipsCDi:
+					types.Add(DiscType.CD);
+					break;
+				case System.SegaCDMegaCD:
+					types.Add(DiscType.CD);
+					break;
+				case System.SegaDreamcast:
+					types.Add(DiscType.GDROM);
+					break;
+				case System.SegaSaturn:
+					types.Add(DiscType.CD);
+					break;
+				case System.SNKNeoGeoCD:
+					types.Add(DiscType.CD);
+					break;
+				case System.SonyPlayStation:
+					types.Add(DiscType.CD);
+					break;
+				case System.SonyPlayStation2:
+					types.Add(DiscType.CD);
+					types.Add(DiscType.DVD5);
+					types.Add(DiscType.DVD9);
+					break;
+				case System.SonyPlayStation3:
+					types.Add(DiscType.BD25);
+					types.Add(DiscType.BD50);
+					break;
+				case System.SonyPlayStation4:
+					types.Add(DiscType.BD25);
+					types.Add(DiscType.BD50);
+					break;
+				case System.SonyPlayStationPortable:
+					types.Add(DiscType.UMD);
+					break;
+				case System.VMLabsNuon:
+					types.Add(DiscType.DVD5); // TODO: Confirm
+					break;
+				case System.VTechVFlashVSmilePro:
+					types.Add(DiscType.CD);
+					break;
+				case System.ZAPiTGamesGameWaveFamilyEntertainmentSystem:
+					types.Add(DiscType.DVD5);
+					break;
+
+				#endregion
+
+				#region Computers
+
+				case System.AcornArchimedes:
+					types.Add(DiscType.CD);
+					break;
+				case System.AppleMacintosh:
+					types.Add(DiscType.CD);
+					types.Add(DiscType.DVD5);
+					types.Add(DiscType.DVD9);
+					types.Add(DiscType.Floppy);
+					break;
+				case System.CommodoreAmigaCD:
+					types.Add(DiscType.CD);
+					break;
+				case System.FujitsuFMTowns:
+					types.Add(DiscType.CD);
+					break;
+				case System.IBMPCCompatible:
+					types.Add(DiscType.CD);
+					types.Add(DiscType.DVD5);
+					types.Add(DiscType.DVD9);
+					types.Add(DiscType.Floppy);
+					break;
+				case System.NECPC88:
+					types.Add(DiscType.CD);
+					break;
+				case System.NECPC98:
+					types.Add(DiscType.CD);
+					break;
+				case System.SharpX68000:
+					types.Add(DiscType.CD);
+					break;
+
+				#endregion
+
+				#region Arcade
+
+				case System.NamcoSegaNintendoTriforce:
+					types.Add(DiscType.GDROM);
+					break;
+				case System.SegaChihiro:
+					types.Add(DiscType.GDROM);
+					break;
+				case System.SegaLindbergh:
+					types.Add(DiscType.DVD5); // TODO: Confirm
+					break;
+				case System.SegaNaomi:
+					types.Add(DiscType.GDROM);
+					break;
+				case System.SegaNaomi2:
+					types.Add(DiscType.GDROM);
+					break;
+				case System.TABAustriaQuizard:
+					types.Add(DiscType.CD);
+					break;
+				case System.TandyMemorexVisualInformationSystem:
+					types.Add(DiscType.CD);
+					break;
+
+				#endregion
+
+				#region Others
+
+				case System.AudioCD:
+					types.Add(DiscType.CD);
+					break;
+				case System.BDVideo:
+					types.Add(DiscType.BD25);
+					types.Add(DiscType.BD50);
+					break;
+				case System.DVDVideo:
+					types.Add(DiscType.DVD5);
+					types.Add(DiscType.DVD9);
+					break;
+				case System.EnhancedCD:
+					types.Add(DiscType.CD);
+					break;
+				case System.PalmOS:
+					types.Add(DiscType.CD);
+					break;
+				case System.PhilipsCDiDigitalVideo:
+					types.Add(DiscType.CD);
+					break;
+				case System.PhotoCD:
+					types.Add(DiscType.CD);
+					break;
+				case System.PlayStationGameSharkUpdates:
+					types.Add(DiscType.CD);
+					break;
+				case System.TaoiKTV:
+					types.Add(DiscType.CD);
+					break;
+				case System.TomyKissSite:
+					types.Add(DiscType.CD);
+					break;
+				case System.VideoCD:
+					types.Add(DiscType.CD);
+					break;
+
+				#endregion
+
+				case System.NONE:
+				default:
+					types.Add(DiscType.NONE);
+					break;
+			}
+
+			return types;
+		}
+
+		/// <summary>
+		/// Get the DIC command to be used for a given DiscType
+		/// </summary>
+		/// <param name="type">DiscType value to check</param>
+		/// <returns>String containing the command, null on error</returns>
+		public static string GetBaseCommand(DiscType type)
+		{
+			switch (type)
+			{
+				case DiscType.CD:
+					return "cd";
+				case DiscType.DVD5:
+					return "dvd";
+				case DiscType.DVD9:
+					return "dvd";
+				case DiscType.GDROM:
+					return "gd"; // TODO: "swap"?
+				case DiscType.HDDVD:
+					Console.WriteLine("HD-DVD dumping is not supported by DIC");
+					return null;
+				case DiscType.BD25:
+					return "bd";
+				case DiscType.BD50:
+					return "bd";
+
+				// Special Formats
+				case DiscType.GameCubeGameDisc:
+					return "dvd";
+				case DiscType.UMD:
+					Console.WriteLine("UMD dumping is not supported by DIC");
+					return null;
+
+				// Non-optical
+				case DiscType.Floppy:
+					return "fd";
+
+				default:
+					return null;
+			}
+		}
+
+		/// <summary>
+		/// Get list of default parameters for a given system and disc type
+		/// </summary>
+		/// <param name="sys">System value to check</param>
+		/// <param name="type">DiscType value to check</param>
+		/// <returns>List of strings representing the parameters</returns>
+		public static List<string> GetDefaultParameters(System sys, DiscType type)
+		{
+			// First check to see if the combination of system and disctype is valid
+			List<DiscType> validTypes = GetValidDiscTypes(sys);
+			if (!validTypes.Contains(type))
+			{
+				Console.WriteLine("Invalid DiscType '{0}' for System '{1}'", type.ToString(), SystemToString(sys));
+				return null;
+			}
+
+			// Now sort based on disc type
+			List<string> parameters = new List<string>();
+			switch (type)
+			{
+				case DiscType.CD:
+					parameters.Add("/c2 20");
+
+					switch (sys)
+					{
+						case System.AppleMacintosh:
+						case System.IBMPCCompatible:
+							parameters.Add("/ns");
+							parameters.Add("/sf");
+							parameters.Add("/ss");
+							break;
+						case System.NECPCEngineTurboGrafxCD:
+							parameters.Add("/m");
+							break;
+						case System.SonyPlayStation:
+							parameters.Add("/am");
+							break;
+					}
+					break;
+				case DiscType.DVD5:
+					// Currently no defaults set
+					break;
+				case DiscType.DVD9:
+					// Currently no defaults set
+					break;
+				case DiscType.GDROM:
+					parameters.Add("/c2 20");
+					break;
+				case DiscType.HDDVD:
+					Console.WriteLine("HD-DVD dumping is not supported by DIC");
+					break;
+				case DiscType.BD25:
+					// Currently no defaults set
+					break;
+				case DiscType.BD50:
+					// Currently no defaults set
+					break;
+
+				// Special Formats
+				case DiscType.GameCubeGameDisc:
+					parameters.Add("/raw");
+					break;
+				case DiscType.UMD:
+					Console.WriteLine("UMD dumping is not supported by DIC");
+					break;
+
+				// Non-optical
+				case DiscType.Floppy:
+					// Currently no defaults set
+					break;
+			}
+
+			return parameters;
+		}
+	}
+}

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -10,139 +10,139 @@ namespace DICUI
 		/// </summary>
 		/// <param name="sys">System value to convert</param>
 		/// <returns>String representing the value, if possible</returns>
-		public static string SystemToString(System sys)
+		public static string SystemToString(KnownSystem sys)
 		{
 			switch (sys)
 			{
 				#region Consoles
 
-				case System.BandaiPlaydiaQuickInteractiveSystem:
+				case KnownSystem.BandaiPlaydiaQuickInteractiveSystem:
 					return "Bandai Playdia Quick Interactive System";
-				case System.BandaiApplePippin:
+				case KnownSystem.BandaiApplePippin:
 					return "Bandai / Apple Pippin";
-				case System.CommodoreAmigaCD32:
+				case KnownSystem.CommodoreAmigaCD32:
 					return "Commodore Amiga CD32";
-				case System.CommodoreAmigaCDTV:
+				case KnownSystem.CommodoreAmigaCDTV:
 					return "Commodore Amiga CDTV";
-				case System.MattelHyperscan:
+				case KnownSystem.MattelHyperscan:
 					return "Mattel HyperScan";
-				case System.MicrosoftXBOX:
+				case KnownSystem.MicrosoftXBOX:
 					return "Microsoft XBOX";
-				case System.MicrosoftXBOX360:
+				case KnownSystem.MicrosoftXBOX360:
 					return "Microsoft XBOX 360";
-				case System.MicrosoftXBOXOne:
+				case KnownSystem.MicrosoftXBOXOne:
 					return "Microsoft XBOX One";
-				case System.NECPCEngineTurboGrafxCD:
+				case KnownSystem.NECPCEngineTurboGrafxCD:
 					return "NEC PC-Engine / TurboGrafx CD";
-				case System.NECPCFX:
+				case KnownSystem.NECPCFX:
 					return "NEC PC-FX / PC-FXGA";
-				case System.NintendoGameCube:
+				case KnownSystem.NintendoGameCube:
 					return "Nintendo GameCube";
-				case System.NintendoWii:
+				case KnownSystem.NintendoWii:
 					return "Nintendo Wii";
-				case System.NintendoWiiU:
+				case KnownSystem.NintendoWiiU:
 					return "Nintendo Wii U";
-				case System.Panasonic3DOInteractiveMultiplayer:
+				case KnownSystem.Panasonic3DOInteractiveMultiplayer:
 					return "Panasonic 3DO Interactive Multiplayer";
-				case System.PhilipsCDi:
+				case KnownSystem.PhilipsCDi:
 					return "Philips CD-i";
-				case System.SegaCDMegaCD:
+				case KnownSystem.SegaCDMegaCD:
 					return "Sega CD / Mega CD";
-				case System.SegaDreamcast:
+				case KnownSystem.SegaDreamcast:
 					return "Sega Dreamcast";
-				case System.SegaSaturn:
+				case KnownSystem.SegaSaturn:
 					return "Sega Saturn";
-				case System.SNKNeoGeoCD:
+				case KnownSystem.SNKNeoGeoCD:
 					return "SNK Neo Geo CD";
-				case System.SonyPlayStation:
+				case KnownSystem.SonyPlayStation:
 					return "Sony PlayStation";
-				case System.SonyPlayStation2:
+				case KnownSystem.SonyPlayStation2:
 					return "Sony PlayStation 2";
-				case System.SonyPlayStation3:
+				case KnownSystem.SonyPlayStation3:
 					return "Sony PlayStation 3";
-				case System.SonyPlayStation4:
+				case KnownSystem.SonyPlayStation4:
 					return "Sony PlayStation 4";
-				case System.SonyPlayStationPortable:
+				case KnownSystem.SonyPlayStationPortable:
 					return "Sony PlayStation Portable";
-				case System.VMLabsNuon:
+				case KnownSystem.VMLabsNuon:
 					return "VM Labs NUON";
-				case System.VTechVFlashVSmilePro:
+				case KnownSystem.VTechVFlashVSmilePro:
 					return "VTech V.Flash - V.Smile Pro";
-				case System.ZAPiTGamesGameWaveFamilyEntertainmentSystem:
+				case KnownSystem.ZAPiTGamesGameWaveFamilyEntertainmentSystem:
 					return "ZAPiT Games Game Wave Family Entertainment System";
 
 				#endregion
 
 				#region Computers
 
-				case System.AcornArchimedes:
+				case KnownSystem.AcornArchimedes:
 					return "Acorn Archimedes";
-				case System.AppleMacintosh:
+				case KnownSystem.AppleMacintosh:
 					return "Apple Macintosh";
-				case System.CommodoreAmigaCD:
+				case KnownSystem.CommodoreAmigaCD:
 					return "CommodoreAmigaCD";
-				case System.FujitsuFMTowns:
+				case KnownSystem.FujitsuFMTowns:
 					return "Fujitsu FM Towns series";
-				case System.IBMPCCompatible:
+				case KnownSystem.IBMPCCompatible:
 					return "IBM PC Compatible";
-				case System.NECPC88:
+				case KnownSystem.NECPC88:
 					return "NEC PC-88";
-				case System.NECPC98:
+				case KnownSystem.NECPC98:
 					return "NEC PC-98";
-				case System.SharpX68000:
+				case KnownSystem.SharpX68000:
 					return "Sharp X68000";
 
 				#endregion
 
 				#region Arcade
 
-				case System.NamcoSegaNintendoTriforce:
+				case KnownSystem.NamcoSegaNintendoTriforce:
 					return "Namco / Sega / Nintendo Triforce";
-				case System.NamcoSystem246:
+				case KnownSystem.NamcoSystem246:
 					return "Namco System 246";
-				case System.SegaChihiro:
+				case KnownSystem.SegaChihiro:
 					return "Sega Chihiro";
-				case System.SegaLindbergh:
+				case KnownSystem.SegaLindbergh:
 					return "Sega Lindbergh";
-				case System.SegaNaomi:
+				case KnownSystem.SegaNaomi:
 					return "Sega Naomi";
-				case System.SegaNaomi2:
+				case KnownSystem.SegaNaomi2:
 					return "Sega Naomi 2";
-				case System.TABAustriaQuizard:
+				case KnownSystem.TABAustriaQuizard:
 					return "TAB-Austria Quizard";
-				case System.TandyMemorexVisualInformationSystem:
+				case KnownSystem.TandyMemorexVisualInformationSystem:
 					return "Tandy / Memorex Visual Information System";
 
 				#endregion
 
 				#region Others
 
-				case System.AudioCD:
+				case KnownSystem.AudioCD:
 					return "Audio CD";
-				case System.BDVideo:
+				case KnownSystem.BDVideo:
 					return "BD-Video";
-				case System.DVDVideo:
+				case KnownSystem.DVDVideo:
 					return "DVD-Video";
-				case System.EnhancedCD:
+				case KnownSystem.EnhancedCD:
 					return "Enhanced CD";
-				case System.PalmOS:
+				case KnownSystem.PalmOS:
 					return "PalmOS";
-				case System.PhilipsCDiDigitalVideo:
+				case KnownSystem.PhilipsCDiDigitalVideo:
 					return "Philips CD-i Digital Video";
-				case System.PhotoCD:
+				case KnownSystem.PhotoCD:
 					return "Photo CD";
-				case System.PlayStationGameSharkUpdates:
+				case KnownSystem.PlayStationGameSharkUpdates:
 					return "PlayStation GameShark Updates";
-				case System.TaoiKTV:
+				case KnownSystem.TaoiKTV:
 					return "Tao iKTV";
-				case System.TomyKissSite:
+				case KnownSystem.TomyKissSite:
 					return "Tomy Kiss-Site";
-				case System.VideoCD:
+				case KnownSystem.VideoCD:
 					return "Video CD";
 
 				#endregion
 
-				case System.NONE:
+				case KnownSystem.NONE:
 				default:
 					return "Unknown";
 			}
@@ -153,7 +153,7 @@ namespace DICUI
 		/// </summary>
 		/// <param name="sys">System value to check</param>
 		/// <returns>List of DiscTypes</returns>
-		public static List<DiscType> GetValidDiscTypes(System sys)
+		public static List<DiscType> GetValidDiscTypes(KnownSystem sys)
 		{
 			List<DiscType> types = new List<DiscType>();
 			
@@ -161,94 +161,94 @@ namespace DICUI
 			{
 				#region Consoles
 
-				case System.BandaiPlaydiaQuickInteractiveSystem:
+				case KnownSystem.BandaiPlaydiaQuickInteractiveSystem:
 					types.Add(DiscType.CD);
 					break;
-				case System.BandaiApplePippin:
+				case KnownSystem.BandaiApplePippin:
 					types.Add(DiscType.CD);
 					break;
-				case System.CommodoreAmigaCD32:
+				case KnownSystem.CommodoreAmigaCD32:
 					types.Add(DiscType.CD);
 					break;
-				case System.CommodoreAmigaCDTV:
+				case KnownSystem.CommodoreAmigaCDTV:
 					types.Add(DiscType.CD);
 					break;
-				case System.MattelHyperscan:
+				case KnownSystem.MattelHyperscan:
 					types.Add(DiscType.CD);
 					break;
-				case System.MicrosoftXBOX:
+				case KnownSystem.MicrosoftXBOX:
 					types.Add(DiscType.CD);
 					types.Add(DiscType.DVD5);
 					break;
-				case System.MicrosoftXBOX360:
+				case KnownSystem.MicrosoftXBOX360:
 					types.Add(DiscType.CD);
 					types.Add(DiscType.DVD9);
 					types.Add(DiscType.HDDVD);
 					break;
-				case System.MicrosoftXBOXOne:
+				case KnownSystem.MicrosoftXBOXOne:
 					types.Add(DiscType.BD25);
 					types.Add(DiscType.BD50);
 					break;
-				case System.NECPCEngineTurboGrafxCD:
+				case KnownSystem.NECPCEngineTurboGrafxCD:
 					types.Add(DiscType.CD);
 					break;
-				case System.NECPCFX:
+				case KnownSystem.NECPCFX:
 					types.Add(DiscType.CD);
 					break;
-				case System.NintendoGameCube:
+				case KnownSystem.NintendoGameCube:
 					types.Add(DiscType.GameCubeGameDisc);
 					break;
-				case System.NintendoWii:
+				case KnownSystem.NintendoWii:
 					types.Add(DiscType.DVD5); // TODO: Confirm
 					types.Add(DiscType.DVD9); // TODO: Confirm
 					break;
-				case System.NintendoWiiU:
+				case KnownSystem.NintendoWiiU:
 					types.Add(DiscType.DVD5); // TODO: Confirm
 					break;
-				case System.Panasonic3DOInteractiveMultiplayer:
+				case KnownSystem.Panasonic3DOInteractiveMultiplayer:
 					types.Add(DiscType.CD);
 					break;
-				case System.PhilipsCDi:
+				case KnownSystem.PhilipsCDi:
 					types.Add(DiscType.CD);
 					break;
-				case System.SegaCDMegaCD:
+				case KnownSystem.SegaCDMegaCD:
 					types.Add(DiscType.CD);
 					break;
-				case System.SegaDreamcast:
+				case KnownSystem.SegaDreamcast:
 					types.Add(DiscType.GDROM);
 					break;
-				case System.SegaSaturn:
+				case KnownSystem.SegaSaturn:
 					types.Add(DiscType.CD);
 					break;
-				case System.SNKNeoGeoCD:
+				case KnownSystem.SNKNeoGeoCD:
 					types.Add(DiscType.CD);
 					break;
-				case System.SonyPlayStation:
+				case KnownSystem.SonyPlayStation:
 					types.Add(DiscType.CD);
 					break;
-				case System.SonyPlayStation2:
+				case KnownSystem.SonyPlayStation2:
 					types.Add(DiscType.CD);
 					types.Add(DiscType.DVD5);
 					types.Add(DiscType.DVD9);
 					break;
-				case System.SonyPlayStation3:
+				case KnownSystem.SonyPlayStation3:
 					types.Add(DiscType.BD25);
 					types.Add(DiscType.BD50);
 					break;
-				case System.SonyPlayStation4:
+				case KnownSystem.SonyPlayStation4:
 					types.Add(DiscType.BD25);
 					types.Add(DiscType.BD50);
 					break;
-				case System.SonyPlayStationPortable:
+				case KnownSystem.SonyPlayStationPortable:
 					types.Add(DiscType.UMD);
 					break;
-				case System.VMLabsNuon:
+				case KnownSystem.VMLabsNuon:
 					types.Add(DiscType.DVD5); // TODO: Confirm
 					break;
-				case System.VTechVFlashVSmilePro:
+				case KnownSystem.VTechVFlashVSmilePro:
 					types.Add(DiscType.CD);
 					break;
-				case System.ZAPiTGamesGameWaveFamilyEntertainmentSystem:
+				case KnownSystem.ZAPiTGamesGameWaveFamilyEntertainmentSystem:
 					types.Add(DiscType.DVD5);
 					break;
 
@@ -256,34 +256,34 @@ namespace DICUI
 
 				#region Computers
 
-				case System.AcornArchimedes:
+				case KnownSystem.AcornArchimedes:
 					types.Add(DiscType.CD);
 					break;
-				case System.AppleMacintosh:
-					types.Add(DiscType.CD);
-					types.Add(DiscType.DVD5);
-					types.Add(DiscType.DVD9);
-					types.Add(DiscType.Floppy);
-					break;
-				case System.CommodoreAmigaCD:
-					types.Add(DiscType.CD);
-					break;
-				case System.FujitsuFMTowns:
-					types.Add(DiscType.CD);
-					break;
-				case System.IBMPCCompatible:
+				case KnownSystem.AppleMacintosh:
 					types.Add(DiscType.CD);
 					types.Add(DiscType.DVD5);
 					types.Add(DiscType.DVD9);
 					types.Add(DiscType.Floppy);
 					break;
-				case System.NECPC88:
+				case KnownSystem.CommodoreAmigaCD:
 					types.Add(DiscType.CD);
 					break;
-				case System.NECPC98:
+				case KnownSystem.FujitsuFMTowns:
 					types.Add(DiscType.CD);
 					break;
-				case System.SharpX68000:
+				case KnownSystem.IBMPCCompatible:
+					types.Add(DiscType.CD);
+					types.Add(DiscType.DVD5);
+					types.Add(DiscType.DVD9);
+					types.Add(DiscType.Floppy);
+					break;
+				case KnownSystem.NECPC88:
+					types.Add(DiscType.CD);
+					break;
+				case KnownSystem.NECPC98:
+					types.Add(DiscType.CD);
+					break;
+				case KnownSystem.SharpX68000:
 					types.Add(DiscType.CD);
 					break;
 
@@ -291,25 +291,25 @@ namespace DICUI
 
 				#region Arcade
 
-				case System.NamcoSegaNintendoTriforce:
+				case KnownSystem.NamcoSegaNintendoTriforce:
 					types.Add(DiscType.GDROM);
 					break;
-				case System.SegaChihiro:
+				case KnownSystem.SegaChihiro:
 					types.Add(DiscType.GDROM);
 					break;
-				case System.SegaLindbergh:
+				case KnownSystem.SegaLindbergh:
 					types.Add(DiscType.DVD5); // TODO: Confirm
 					break;
-				case System.SegaNaomi:
+				case KnownSystem.SegaNaomi:
 					types.Add(DiscType.GDROM);
 					break;
-				case System.SegaNaomi2:
+				case KnownSystem.SegaNaomi2:
 					types.Add(DiscType.GDROM);
 					break;
-				case System.TABAustriaQuizard:
+				case KnownSystem.TABAustriaQuizard:
 					types.Add(DiscType.CD);
 					break;
-				case System.TandyMemorexVisualInformationSystem:
+				case KnownSystem.TandyMemorexVisualInformationSystem:
 					types.Add(DiscType.CD);
 					break;
 
@@ -317,45 +317,45 @@ namespace DICUI
 
 				#region Others
 
-				case System.AudioCD:
+				case KnownSystem.AudioCD:
 					types.Add(DiscType.CD);
 					break;
-				case System.BDVideo:
+				case KnownSystem.BDVideo:
 					types.Add(DiscType.BD25);
 					types.Add(DiscType.BD50);
 					break;
-				case System.DVDVideo:
+				case KnownSystem.DVDVideo:
 					types.Add(DiscType.DVD5);
 					types.Add(DiscType.DVD9);
 					break;
-				case System.EnhancedCD:
+				case KnownSystem.EnhancedCD:
 					types.Add(DiscType.CD);
 					break;
-				case System.PalmOS:
+				case KnownSystem.PalmOS:
 					types.Add(DiscType.CD);
 					break;
-				case System.PhilipsCDiDigitalVideo:
+				case KnownSystem.PhilipsCDiDigitalVideo:
 					types.Add(DiscType.CD);
 					break;
-				case System.PhotoCD:
+				case KnownSystem.PhotoCD:
 					types.Add(DiscType.CD);
 					break;
-				case System.PlayStationGameSharkUpdates:
+				case KnownSystem.PlayStationGameSharkUpdates:
 					types.Add(DiscType.CD);
 					break;
-				case System.TaoiKTV:
+				case KnownSystem.TaoiKTV:
 					types.Add(DiscType.CD);
 					break;
-				case System.TomyKissSite:
+				case KnownSystem.TomyKissSite:
 					types.Add(DiscType.CD);
 					break;
-				case System.VideoCD:
+				case KnownSystem.VideoCD:
 					types.Add(DiscType.CD);
 					break;
 
 				#endregion
 
-				case System.NONE:
+				case KnownSystem.NONE:
 				default:
 					types.Add(DiscType.NONE);
 					break;
@@ -411,7 +411,7 @@ namespace DICUI
 		/// <param name="sys">System value to check</param>
 		/// <param name="type">DiscType value to check</param>
 		/// <returns>List of strings representing the parameters</returns>
-		public static List<string> GetDefaultParameters(System sys, DiscType type)
+		public static List<string> GetDefaultParameters(KnownSystem sys, DiscType type)
 		{
 			// First check to see if the combination of system and disctype is valid
 			List<DiscType> validTypes = GetValidDiscTypes(sys);
@@ -430,16 +430,16 @@ namespace DICUI
 
 					switch (sys)
 					{
-						case System.AppleMacintosh:
-						case System.IBMPCCompatible:
+						case KnownSystem.AppleMacintosh:
+						case KnownSystem.IBMPCCompatible:
 							parameters.Add("/ns");
 							parameters.Add("/sf");
 							parameters.Add("/ss");
 							break;
-						case System.NECPCEngineTurboGrafxCD:
+						case KnownSystem.NECPCEngineTurboGrafxCD:
 							parameters.Add("/m");
 							break;
-						case System.SonyPlayStation:
+						case KnownSystem.SonyPlayStation:
 							parameters.Add("/am");
 							break;
 					}


### PR DESCRIPTION
This PR adds enumerations, helper methods, and combobox automation to make the system more extensible in the future. This includes things like automatically getting the list of items in the box, setting default parameters better, and even filling in some previously-missing formats.

I encourage local testing to make sure that all items are still working as intended.

My merge with the main branch (Merge branch 'master') removes the unnecessary additional ECC check for CDs. If the EccEdc executable is in the folder with DIC, it will automatically run and create the required _eccEdc.txt file. I was trying to mention this in #21 but to no avail.