### PR TITLE
Cleanup/Automation

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -42,24 +42,17 @@
             <Label Grid.Row="3" Grid.Column="0" VerticalAlignment="Center">Drive Letter</Label>
             <Label Grid.Row="4" Grid.Column="0" VerticalAlignment="Center">Drive Speed</Label>
 
-            <ComboBox x:Name="cmb_DiscType" Grid.Row="0" Grid.Column="1" Height="22" DropDownClosed="cmb_DiscType_DropDownClosed" SelectionChanged="cmb_DiscType_SelectionChanged" />
+            <ComboBox x:Name="cmb_DiscType" Grid.Row="0" Grid.Column="1" Height="22" SelectionChanged="cmb_DiscType_SelectionChanged" />
 
-           
             <TextBox x:Name="txt_OutputFilename" Grid.Row="1" Grid.Column="1" Height="22"></TextBox>
 
-            <TextBox x:Name="txt_OutputDirectory" Grid.Row="2" Grid.Column="1" Height="22" Width="345" HorizontalAlignment="left" Text="ISO" ></TextBox>
-            <Button x:Name="BTN_OutputDirectoryBrowse" Grid.Row="2" Grid.Column="1" Height="22" Width="50" HorizontalAlignment="Right" Content="Browse" Click="BTN_OutputDirectoryBrowse_Click" ></Button>
+            <TextBox x:Name="txt_OutputDirectory" Grid.Row="2" Grid.Column="1" Height="22" Width="345" HorizontalAlignment="left" Text="ISO" />
+            <Button x:Name="btn_OutputDirectoryBrowse" Grid.Row="2" Grid.Column="1" Height="22" Width="50" HorizontalAlignment="Right" Content="Browse" Click="btn_OutputDirectoryBrowse_Click"/>
 
-            <ComboBox x:Name="cmb_DriveLetter" Grid.Row="3" Grid.Column="1" Height="22" Width="397" HorizontalAlignment="left" SelectionChanged="cmb_DriveLetter_SelectionChanged"></ComboBox>
+            <ComboBox x:Name="cmb_DriveLetter" Grid.Row="3" Grid.Column="1" Height="22" Width="397" HorizontalAlignment="left" SelectionChanged="cmb_DriveLetter_SelectionChanged"/>
 
-            <ComboBox x:Name="cmb_DriveSpeed" Grid.Row="4" Grid.Column="1" Height="22" Width="60" HorizontalAlignment="left"  SelectionChanged="cmb_DriveSpeed_SelectionChanged">
-                <ComboBoxItem Content="4"/>
-                <ComboBoxItem Content="8"/>
-                <ComboBoxItem Content="16"/>
-                <ComboBoxItem Content="48"/>
-                <ComboBoxItem Content="Custom"/>
-            </ComboBox>
-        </Grid>
+			<ComboBox x:Name="cmb_DriveSpeed" Grid.Row="4" Grid.Column="1" Height="22" Width="60" HorizontalAlignment="left"  SelectionChanged="cmb_DriveSpeed_SelectionChanged"/>
+		</Grid>
 
         <Grid Grid.Row="1" Grid.Column="0" Margin="15,19.6,15.2,9.8" Grid.ColumnSpan="2">
             <Grid.ColumnDefinitions>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -51,8 +51,8 @@
 
             <ComboBox x:Name="cmb_DriveLetter" Grid.Row="3" Grid.Column="1" Height="22" Width="397" HorizontalAlignment="left" SelectionChanged="cmb_DriveLetter_SelectionChanged"/>
 
-			<ComboBox x:Name="cmb_DriveSpeed" Grid.Row="4" Grid.Column="1" Height="22" Width="60" HorizontalAlignment="left"  SelectionChanged="cmb_DriveSpeed_SelectionChanged"/>
-		</Grid>
+            <ComboBox x:Name="cmb_DriveSpeed" Grid.Row="4" Grid.Column="1" Height="22" Width="60" HorizontalAlignment="left"/>
+        </Grid>
 
         <Grid Grid.Row="1" Grid.Column="0" Margin="15,19.6,15.2,9.8" Grid.ColumnSpan="2">
             <Grid.ColumnDefinitions>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -140,7 +140,7 @@ namespace DICUI
         private void PopulateDriveSpeeds()
         {
             cmb_DriveSpeed.ItemsSource = _driveSpeeds;
-            cmb_DriveSpeed.SelectedIndex = 0;
+            cmb_DriveSpeed.SelectedItem = 8;
         }
 
         /// <summary>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -89,7 +89,7 @@ namespace DICUI
             {
                 case KnownSystem.MicrosoftXBOXOne:
                 case KnownSystem.SonyPlayStation4:
-					Process processXboneOrPS4 = new Process()
+					Process sgraw = new Process()
 					{
 						StartInfo = new ProcessStartInfo()
 						{
@@ -97,8 +97,8 @@ namespace DICUI
 							Arguments = "-v -r 4100 -R " + driveLetter + ": " + "ad 01 00 00 00 00 00 00 10 04 00 00 -o \"PIC.bin\""
 						},
 					};
-                    processXboneOrPS4.Start();
-                    processXboneOrPS4.WaitForExit();
+                    sgraw.Start();
+                    sgraw.WaitForExit();
                     break;
                 case KnownSystem.SonyPlayStation:
                     // TODO: Direct invocation of program instead of via Batch File
@@ -110,10 +110,10 @@ namespace DICUI
                         writetext.WriteLine("psxt001z" + " " + "--libcrypt " + "\"" + outputDirectory + "\\" + outputFileName + ".sub\" > " + "\"" + outputDirectory + "\\" + "libcrypt.txt");
                         writetext.WriteLine("psxt001z" + " " + "--libcryptdrvfast " + driveLetter + " > " + "\"" + outputDirectory + "\\" + "libcryptdrv.log");
                     }
-                    Process processpsx = new Process();
-                    processpsx.StartInfo.FileName = "PSX" + guid + ".bat";
-                    processpsx.Start();
-                    processpsx.WaitForExit();
+                    Process psxt = new Process();
+                    psxt.StartInfo.FileName = "PSX" + guid + ".bat";
+                    psxt.Start();
+                    psxt.WaitForExit();
                     break;
             }
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -141,7 +141,6 @@ namespace DICUI
         {
             cmb_DriveSpeed.ItemsSource = _driveSpeeds;
             cmb_DriveSpeed.SelectedIndex = 0;
-            cmb_DriveSpeed_SelectionChanged(null, null);
         }
 
         /// <summary>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -204,8 +204,8 @@ namespace DICUI
                 case DiscType.NONE:
                     lbl_Status.Content = "Please select a valid disc type";
                     break;
-				case DiscType.GameCubeGameDisc:
-				case DiscType.GDROM:
+                case DiscType.GameCubeGameDisc:
+                case DiscType.GDROM:
                     lbl_Status.Content = string.Format("{0} discs are partially supported by DIC", Utilities.DiscTypeToString(tuple.Item3));
                     break;
                 case DiscType.HDDVD:

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -49,53 +49,17 @@ namespace DICUI
 
         private void cmb_DiscType_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            // If we're on a separator, go to the next item
-            var tuple = cmb_DiscType.SelectedItem as Tuple<string, KnownSystem?, DiscType?>;
-            if (tuple.Item2 == null && tuple.Item3 == null)
-            {
-                cmb_DiscType.SelectedIndex++;
-                tuple = cmb_DiscType.SelectedItem as Tuple<string, KnownSystem?, DiscType?>;
-            }
-
-            // If we're on an unsupported type, update the status accordingly
-            switch (tuple.Item3)
-            {
-                case DiscType.NONE:
-                    lbl_Status.Content = "Please select a valid disc type";
-                    break;
-                case DiscType.GDROM:
-                    lbl_Status.Content = string.Format("{0} discs are partially supported by DIC", Utilities.DiscTypeToString(tuple.Item3));
-                    break;
-                case DiscType.GameCubeGameDisc:
-                case DiscType.HDDVD:
-                case DiscType.UMD:
-                    lbl_Status.Content = string.Format("{0} discs are not currently supported by DIC", Utilities.DiscTypeToString(tuple.Item3));
-                    break;
-                default:
-                    lbl_Status.Content = string.Format("{0} ready to dump", Utilities.DiscTypeToString(tuple.Item3));
-                    break;
-            }
-
-            // If we're in a type that doesn't support drive speeds
-            switch (tuple.Item3)
-            {
-                case DiscType.BD25:
-                case DiscType.BD50:
-                    cmb_DriveSpeed.IsEnabled = false;
-                    break;
-                default:
-                    cmb_DriveSpeed.IsEnabled = true;
-                    break;
-            }
+            EnsureDiscInformation();
         }
 
         private void cmb_DriveLetter_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            var tuple = cmb_DriveLetter.SelectedItem as Tuple<char, string>;
-            txt_OutputDirectory.Text = "ISO" + Path.DirectorySeparatorChar + tuple.Item2;
+            GetOutputDirectoryName();
         }
 
         #endregion
+
+        #region Helpers
 
         /// <summary>
         /// Get a complete list of supported systems and fill the combo box
@@ -125,12 +89,12 @@ namespace DICUI
             if (cmb_DriveLetter.Items.Count > 0)
             {
                 lbl_Status.Content = "Valid optical disc found! Choose your Disc Type";
-				btn_Start.IsEnabled = true;
-			}
+                btn_Start.IsEnabled = true;
+            }
             else
             {
                 lbl_Status.Content = "No valid optical disc found!";
-				btn_Start.IsEnabled = false;
+                btn_Start.IsEnabled = false;
             }
         }
 
@@ -221,5 +185,62 @@ namespace DICUI
 
             btn_Start.IsEnabled = true;
         }
+
+        /// <summary>
+        /// Ensure information is consistent with the currently selected disc type
+        /// </summary>
+        private void EnsureDiscInformation()
+        {
+            // If we're on a separator, go to the next item
+            var tuple = cmb_DiscType.SelectedItem as Tuple<string, KnownSystem?, DiscType?>;
+            if (tuple.Item2 == null && tuple.Item3 == null)
+            {
+                cmb_DiscType.SelectedIndex++;
+                tuple = cmb_DiscType.SelectedItem as Tuple<string, KnownSystem?, DiscType?>;
+            }
+
+            // If we're on an unsupported type, update the status accordingly
+            switch (tuple.Item3)
+            {
+                case DiscType.NONE:
+                    lbl_Status.Content = "Please select a valid disc type";
+                    break;
+                case DiscType.GDROM:
+                    lbl_Status.Content = string.Format("{0} discs are partially supported by DIC", Utilities.DiscTypeToString(tuple.Item3));
+                    break;
+                case DiscType.GameCubeGameDisc:
+                case DiscType.HDDVD:
+                case DiscType.UMD:
+                    lbl_Status.Content = string.Format("{0} discs are not currently supported by DIC", Utilities.DiscTypeToString(tuple.Item3));
+                    break;
+                default:
+                    lbl_Status.Content = string.Format("{0} ready to dump", Utilities.DiscTypeToString(tuple.Item3));
+                    break;
+            }
+
+            // If we're in a type that doesn't support drive speeds
+            switch (tuple.Item3)
+            {
+                case DiscType.BD25:
+                case DiscType.BD50:
+                    cmb_DriveSpeed.IsEnabled = false;
+                    break;
+                default:
+                    cmb_DriveSpeed.IsEnabled = true;
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Get the default output directory name from the currently selected drive
+        /// </summary>
+        /// <remarks>TODO: Make the "ISO" part of the default configurable in UI or Settings</remarks>
+        private void GetOutputDirectoryName()
+        {
+            var tuple = cmb_DriveLetter.SelectedItem as Tuple<char, string>;
+            txt_OutputDirectory.Text = "ISO" + Path.DirectorySeparatorChar + tuple.Item2;
+        }
+
+        #endregion
     }
 }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -103,9 +103,6 @@ namespace DICUI
                     // TODO: Direct invocation of program instead of via Batch File
                     using (StreamWriter writetext = new StreamWriter("PSX" + guid + ".bat"))
                     {
-                        writetext.WriteLine("edccchk" + " " + "\"" + outputDirectory + "\\" + outputFileName + ".bin" + "\" > " + "\"" + outputDirectory + "\\" + "edccchk1.txt");
-                        writetext.WriteLine("edccchk" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 1).bin" + "\" > " + "\"" + outputDirectory + "\\" + "edccchk1.txt");
-                        writetext.WriteLine("edccchk" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 01).bin" + "\" > " + "\"" + outputDirectory + "\\" + "edccchk1.txt");
                         writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + ".bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z1.txt");
                         writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 1).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z2.txt");
                         writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 01).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z3.txt");

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -89,11 +89,6 @@ namespace DICUI
             }
         }
 
-        private void cmb_DriveSpeed_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            // No-op?
-        }
-
         private void cmb_DriveLetter_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             var tuple = cmb_DriveLetter.SelectedItem as Tuple<char, string>;

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -11,7 +11,12 @@ namespace DICUI
 {
     public partial class MainWindow : Window
     {
-        private const string dicPath = "Programs\\DiscImageCreator.exe"; // TODO: Make configurable in UI or in Settings
+        // TODO: Make configurable in UI or in Settings
+        private const string defaultOutputPath = "ISO";
+        private const string dicPath = "Programs\\DiscImageCreator.exe";
+        private const string psxtPath = "psxt001z.exe";
+        private const string sgRawPath = "sg_raw.exe";
+
         private List<Tuple<char, string>> _drives { get; set; }
         private List<int> _driveSpeeds { get { return new List<int> { 1, 2, 3, 4, 6, 8, 12, 16, 20, 24, 32, 40, 44, 48, 52, 56, 72 }; } }
         private List<Tuple<string, KnownSystem?, DiscType?>> _systems { get; set; }
@@ -159,7 +164,7 @@ namespace DICUI
                     {
                         StartInfo = new ProcessStartInfo()
                         {
-                            FileName = "sg_raw.exe", // TODO: Make this configurable
+                            FileName = sgRawPath,
                             Arguments = "-v -r 4100 -R " + driveLetter + ": " + "ad 01 00 00 00 00 00 00 10 04 00 00 -o \"PIC.bin\""
                         },
                     };
@@ -170,12 +175,13 @@ namespace DICUI
                     // TODO: Direct invocation of program instead of via Batch File
                     using (StreamWriter writetext = new StreamWriter("PSX" + guid + ".bat"))
                     {
-                        writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + ".bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z1.txt");
-                        writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 1).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z2.txt");
-                        writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 01).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z3.txt");
-                        writetext.WriteLine("psxt001z" + " " + "--libcrypt " + "\"" + outputDirectory + "\\" + outputFileName + ".sub\" > " + "\"" + outputDirectory + "\\" + "libcrypt.txt");
-                        writetext.WriteLine("psxt001z" + " " + "--libcryptdrvfast " + driveLetter + " > " + "\"" + outputDirectory + "\\" + "libcryptdrv.log");
+                        writetext.WriteLine(psxtPath + " " + "\"" + outputDirectory + "\\" + outputFileName + ".bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z1.txt");
+                        writetext.WriteLine(psxtPath + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 1).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z2.txt");
+                        writetext.WriteLine(psxtPath + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 01).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z3.txt");
+                        writetext.WriteLine(psxtPath + " " + "--libcrypt " + "\"" + outputDirectory + "\\" + outputFileName + ".sub\" > " + "\"" + outputDirectory + "\\" + "libcrypt.txt");
+                        writetext.WriteLine(psxtPath + " " + "--libcryptdrvfast " + driveLetter + " > " + "\"" + outputDirectory + "\\" + "libcryptdrv.log");
                     }
+
                     Process psxt = new Process();
                     psxt.StartInfo.FileName = "PSX" + guid + ".bat";
                     psxt.Start();
@@ -234,7 +240,6 @@ namespace DICUI
         /// <summary>
         /// Get the default output directory name from the currently selected drive
         /// </summary>
-        /// <remarks>TODO: Make the "ISO" part of the default configurable in UI or Settings</remarks>
         private void GetOutputNames()
         {
             var driveTuple = cmb_DriveLetter.SelectedItem as Tuple<char, string>;
@@ -244,7 +249,7 @@ namespace DICUI
             {
                 if (String.IsNullOrWhiteSpace(txt_OutputDirectory.Text))
                 {
-                    txt_OutputDirectory.Text = "ISO";
+                    txt_OutputDirectory.Text = defaultOutputPath;
                 }
 
                 if (discTuple != null)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -142,14 +142,25 @@ namespace DICUI
             // Get the discType and processArguments from a given system and disc combo
             var selected = cmb_DiscType.SelectedValue as Tuple<string, KnownSystem?, DiscType?>;
             string discType = Utilities.GetBaseCommand(selected.Item3);
-            string defaultArguments = string.Join(" ", Utilities.GetDefaultParameters(selected.Item2, selected.Item3));
+            List<string> defaultParams = Utilities.GetDefaultParameters(selected.Item2, selected.Item3);
+
+            // Validate that everything is good
+            if (discType == null || defaultParams == null)
+            {
+                lbl_Status.Content = "Error! Current configuration is not supported!";
+                return;
+            }
 
             await Task.Run(
                 () =>
                 {
                     Process process = new Process();
                     process.StartInfo.FileName = dicPath;
-                    process.StartInfo.Arguments = discType + " " + driveLetter + " \"" + Path.Combine(outputDirectory, outputFileName) + "\" " + driveSpeed + " " + defaultArguments;
+                    process.StartInfo.Arguments = discType
+                        + " " + driveLetter
+                        + " \"" + Path.Combine(outputDirectory, outputFileName) + "\" "
+                        + (selected.Item3 != DiscType.BD25 && selected.Item3 != DiscType.BD50 ? driveSpeed + " " : "")
+                        + string.Join(" ", defaultParams);
                     process.Start();
                     process.WaitForExit();
                 });

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -89,13 +89,14 @@ namespace DICUI
             {
                 case KnownSystem.MicrosoftXBOXOne:
                 case KnownSystem.SonyPlayStation4:
-                    // TODO: Direct invocation of program instead of via Batch File
-                    using (StreamWriter writetext = new StreamWriter("XboneOrPS4" + guid + ".bat"))
-                    {
-                        writetext.WriteLine("sg_raw.exe -v -r 4100 -R " + driveLetter + ": " + "ad 01 00 00 00 00 00 00 10 04 00 00 -o \"PIC.bin\"");
-                    }
-                    Process processXboneOrPS4 = new Process();
-                    processXboneOrPS4.StartInfo.FileName = "XboneOrPS4" + guid + ".bat";
+					Process processXboneOrPS4 = new Process()
+					{
+						StartInfo = new ProcessStartInfo()
+						{
+							FileName = "sg_raw.exe", // TODO: Make this configurable
+							Arguments = "-v -r 4100 -R " + driveLetter + ": " + "ad 01 00 00 00 00 00 00 10 04 00 00 -o \"PIC.bin\""
+						},
+					};
                     processXboneOrPS4.Start();
                     processXboneOrPS4.WaitForExit();
                     break;

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -144,7 +144,6 @@ namespace DICUI
                     Process process = new Process();
                     process.StartInfo.FileName = dicPath;
                     process.StartInfo.Arguments = discType + " " + driveLetter + " \"" + outputDirectory + "\\" + outputFileName + "\" " + driveSpeed + " " + processArguments;
-                    Console.WriteLine(process.StartInfo.Arguments);
                     process.Start();
                     process.WaitForExit();
                 });
@@ -205,10 +204,10 @@ namespace DICUI
                 case DiscType.NONE:
                     lbl_Status.Content = "Please select a valid disc type";
                     break;
-                case DiscType.GDROM:
+				case DiscType.GameCubeGameDisc:
+				case DiscType.GDROM:
                     lbl_Status.Content = string.Format("{0} discs are partially supported by DIC", Utilities.DiscTypeToString(tuple.Item3));
                     break;
-                case DiscType.GameCubeGameDisc:
                 case DiscType.HDDVD:
                 case DiscType.UMD:
                     lbl_Status.Content = string.Format("{0} discs are not currently supported by DIC", Utilities.DiscTypeToString(tuple.Item3));

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.IO;
@@ -13,140 +12,39 @@ namespace DICUI
     public partial class MainWindow : Window
     {
         private const string dicPath = "Programs\\DiscImageCreator.exe"; // TODO: Make configurable in UI or in Settings
+        private List<Tuple<char, string>> _drives { get; set; }
+        private List<int> _driveSpeeds { get { return new List<int> { 1, 2, 3, 4, 6, 8, 12, 16, 20, 24, 32, 40, 44, 48, 52, 56, 72 }; } }
         private List<Tuple<string, KnownSystem?, DiscType?>> _systems { get; set; }
-
-        public void ScanForDisk()
-        {
-            btn_Search.IsEnabled = false;
-            cmb_DriveLetter.Items.Clear();
-            foreach (var d in DriveInfo.GetDrives().Where(d => d.DriveType == DriveType.CDRom))
-            {
-                if (d.IsReady == true)
-                {
-                    txt_OutputFilename.Text = d.VolumeLabel;
-                    
-                    if (txt_OutputFilename.Text == "")
-                    {
-                        txt_OutputFilename.Text = "unknown";
-                    }
-                    cmb_DriveLetter.Items.Add(d.Name + d.VolumeLabel);
-                    cmb_DriveLetter.SelectedIndex = 0;
-                    txt_OutputDirectory.Text = "ISO" + "\\" + txt_OutputFilename.Text;
-                    lbl_Status.Content = "CD or DVD found ! Choose your Disc Type";
-                    btn_Start.IsEnabled = true;
-                    cmb_DriveSpeed.Text = "8";
-                    break;
-                }
-                else
-                {
-                    cmb_DriveLetter.Items.Add(d.Name + " (No Disc Found or Not supported by Windows)");
-                }
-
-                btn_Search.IsEnabled = true;
-            }
-        }
-
-        public void BrowseFolder()
-        {
-            WinForms.FolderBrowserDialog folderDialog = new WinForms.FolderBrowserDialog { ShowNewFolderButton = false, SelectedPath = System.AppDomain.CurrentDomain.BaseDirectory };
-            WinForms.DialogResult result = folderDialog.ShowDialog();
-
-            if (result == WinForms.DialogResult.OK)
-            {
-                String sPath = folderDialog.SelectedPath;
-                txt_OutputDirectory.Text = sPath;
-            }
-        }
-
-        public async void StartDumping()
-        {
-            // Local variables
-            string driveLetter = cmb_DriveLetter.Text;
-            string outputDirectory = txt_OutputDirectory.Text;
-            string outputFileName = txt_OutputFilename.Text;
-            string driveSpeed = cmb_DriveSpeed.Text;
-            btn_Start.IsEnabled = false;
-
-            // Get the discType and processArguments from a given system and disc combo
-            var selected = cmb_DiscType.SelectedValue as Tuple<string, KnownSystem?, DiscType?>;
-            string discType = Utilities.GetBaseCommand(selected.Item3);
-            string processArguments = string.Join(" ", Utilities.GetDefaultParameters(selected.Item2, selected.Item3));
-
-            await Task.Run(
-                () =>
-                {
-                    Process process = new Process();
-                    process.StartInfo.FileName = dicPath;
-                    process.StartInfo.Arguments = discType + " " + driveLetter + " \"" + outputDirectory + "\\" + outputFileName + "\" " + driveSpeed + " " + processArguments;
-                    Console.WriteLine(process.StartInfo.Arguments);
-                    process.Start();
-                    process.WaitForExit();
-                });
-
-            // Special cases
-            string guid = Guid.NewGuid().ToString();
-            switch (selected.Item2)
-            {
-                case KnownSystem.MicrosoftXBOXOne:
-                case KnownSystem.SonyPlayStation4:
-					Process sgraw = new Process()
-					{
-						StartInfo = new ProcessStartInfo()
-						{
-							FileName = "sg_raw.exe", // TODO: Make this configurable
-							Arguments = "-v -r 4100 -R " + driveLetter + ": " + "ad 01 00 00 00 00 00 00 10 04 00 00 -o \"PIC.bin\""
-						},
-					};
-                    sgraw.Start();
-                    sgraw.WaitForExit();
-                    break;
-                case KnownSystem.SonyPlayStation:
-                    // TODO: Direct invocation of program instead of via Batch File
-                    using (StreamWriter writetext = new StreamWriter("PSX" + guid + ".bat"))
-                    {
-                        writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + ".bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z1.txt");
-                        writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 1).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z2.txt");
-                        writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 01).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z3.txt");
-                        writetext.WriteLine("psxt001z" + " " + "--libcrypt " + "\"" + outputDirectory + "\\" + outputFileName + ".sub\" > " + "\"" + outputDirectory + "\\" + "libcrypt.txt");
-                        writetext.WriteLine("psxt001z" + " " + "--libcryptdrvfast " + driveLetter + " > " + "\"" + outputDirectory + "\\" + "libcryptdrv.log");
-                    }
-                    Process psxt = new Process();
-                    psxt.StartInfo.FileName = "PSX" + guid + ".bat";
-                    psxt.Start();
-                    psxt.WaitForExit();
-                    break;
-            }
-
-            btn_Start.IsEnabled = true;
-        }
 
         public MainWindow()
         {
             InitializeComponent();
 
-            // Populate the list of systems and add it to the combo box
-            _systems = Utilities.CreateListOfSystems();
-            cmb_DiscType.ItemsSource = _systems;
-            cmb_DiscType.DisplayMemberPath = "Item1";
-            cmb_DiscType.SelectedIndex = 0;
-            cmb_DiscType_SelectionChanged(null, null);
+            // Populate the list of systems
+            PopulateSystems();
 
-            ScanForDisk();
+            // Populate the list of drives
+            PopulateDrives();
+
+            // Populate the list of drive speeds
+            PopulateDriveSpeeds();
         }
+
+        #region Events
 
         private void btn_Start_Click(object sender, RoutedEventArgs e)
         {
-            StartDumping();  
+            StartDumping();
         }
 
-        private void BTN_OutputDirectoryBrowse_Click(object sender, RoutedEventArgs e)
+        private void btn_OutputDirectoryBrowse_Click(object sender, RoutedEventArgs e)
         {
             BrowseFolder();
         }
 
         private void btn_Search_Click(object sender, RoutedEventArgs e)
         {
-            ScanForDisk();
+            PopulateDrives();
         }
 
         private void cmb_DiscType_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -177,48 +75,157 @@ namespace DICUI
                     lbl_Status.Content = string.Format("{0} ready to dump", Utilities.DiscTypeToString(tuple.Item3));
                     break;
             }
-        }
 
-        private void cmb_DriveSpeed_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            // TODO: Figure out how to keep the list of items while also allowing the custom input
-            if (cmb_DriveSpeed.SelectedIndex == 4)
+            // If we're in a type that doesn't support drive speeds
+            switch (tuple.Item3)
             {
-                cmb_DriveSpeed.Items.Clear();
-                cmb_DriveSpeed.IsEditable = true;
-            }
-        }
-
-        private void cmb_DiscType_DropDownClosed(object sender, EventArgs e)
-        {
-			var tuple = cmb_DiscType.SelectedItem as Tuple<string, KnownSystem?, DiscType?>;
-			switch (tuple.Item2)
-            {
-				case KnownSystem.MicrosoftXBOXOne:
-				case KnownSystem.SonyPlayStation4:
-                    cmb_DriveSpeed.Items.Clear();
+                case DiscType.BD25:
+                case DiscType.BD50:
                     cmb_DriveSpeed.IsEnabled = false;
                     break;
                 default:
                     cmb_DriveSpeed.IsEnabled = true;
-                    cmb_DriveSpeed.Items.Clear();
-                    cmb_DriveSpeed.Items.Add("4");
-                    cmb_DriveSpeed.Items.Add("8");
-                    cmb_DriveSpeed.Items.Add("16");
-                    cmb_DriveSpeed.Items.Add("48");
-                    cmb_DriveSpeed.Items.Add("Custom");
-                    cmb_DriveSpeed.SelectedIndex = 1;
+                    break;
+            }
+        }
+
+        private void cmb_DriveSpeed_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            // No-op?
+        }
+
+        private void cmb_DriveLetter_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var tuple = cmb_DriveLetter.SelectedItem as Tuple<char, string>;
+            txt_OutputDirectory.Text = "ISO" + Path.DirectorySeparatorChar + tuple.Item2;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Get a complete list of supported systems and fill the combo box
+        /// </summary>
+        private void PopulateSystems()
+        {
+            _systems = Utilities.CreateListOfSystems();
+            cmb_DiscType.ItemsSource = _systems;
+            cmb_DiscType.DisplayMemberPath = "Item1";
+            cmb_DiscType.SelectedIndex = 0;
+            cmb_DiscType_SelectionChanged(null, null);
+        }
+
+        /// <summary>
+        /// Get a complete list of active disc drives and fill the combo box
+        /// </summary>
+        /// <remarks>TODO: Find a way for this to periodically run, or have it hook to a "drive change" event</remarks>
+        private void PopulateDrives()
+        {
+            // Populate the list of drives and add it to the combo box
+            _drives = Utilities.CreateListOfDrives();
+            cmb_DriveLetter.ItemsSource = _drives;
+            cmb_DriveLetter.DisplayMemberPath = "Item1";
+            cmb_DriveLetter.SelectedIndex = 0;
+            cmb_DriveLetter_SelectionChanged(null, null);
+
+            if (cmb_DriveLetter.Items.Count > 0)
+            {
+                lbl_Status.Content = "Valid optical disc found! Choose your Disc Type";
+				btn_Start.IsEnabled = true;
+			}
+            else
+            {
+                lbl_Status.Content = "No valid optical disc found!";
+				btn_Start.IsEnabled = false;
+            }
+        }
+
+        /// <summary>
+        /// Get a complete list of (possible) disc drive speeds, and fill the combo box
+        /// </summary>
+        private void PopulateDriveSpeeds()
+        {
+            cmb_DriveSpeed.ItemsSource = _driveSpeeds;
+            cmb_DriveSpeed.SelectedIndex = 0;
+            cmb_DriveSpeed_SelectionChanged(null, null);
+        }
+
+        /// <summary>
+        /// Browse for an output folder
+        /// </summary>
+        private void BrowseFolder()
+        {
+            WinForms.FolderBrowserDialog folderDialog = new WinForms.FolderBrowserDialog { ShowNewFolderButton = false, SelectedPath = System.AppDomain.CurrentDomain.BaseDirectory };
+            WinForms.DialogResult result = folderDialog.ShowDialog();
+
+            if (result == WinForms.DialogResult.OK)
+            {
+                txt_OutputDirectory.Text = folderDialog.SelectedPath;
+            }
+        }
+
+        /// <summary>
+        /// Begin the dumping process using the given inputs
+        /// </summary>
+        private async void StartDumping()
+        {
+            // Local variables
+            string driveLetter = cmb_DriveLetter.Text;
+            string outputDirectory = txt_OutputDirectory.Text;
+            string outputFileName = txt_OutputFilename.Text;
+            string driveSpeed = cmb_DriveSpeed.Text;
+            btn_Start.IsEnabled = false;
+
+            // Get the discType and processArguments from a given system and disc combo
+            var selected = cmb_DiscType.SelectedValue as Tuple<string, KnownSystem?, DiscType?>;
+            string discType = Utilities.GetBaseCommand(selected.Item3);
+            string processArguments = string.Join(" ", Utilities.GetDefaultParameters(selected.Item2, selected.Item3));
+
+            await Task.Run(
+                () =>
+                {
+                    Process process = new Process();
+                    process.StartInfo.FileName = dicPath;
+                    process.StartInfo.Arguments = discType + " " + driveLetter + " \"" + outputDirectory + "\\" + outputFileName + "\" " + driveSpeed + " " + processArguments;
+                    Console.WriteLine(process.StartInfo.Arguments);
+                    process.Start();
+                    process.WaitForExit();
+                });
+
+            // Special cases
+            string guid = Guid.NewGuid().ToString();
+            switch (selected.Item2)
+            {
+                case KnownSystem.MicrosoftXBOXOne:
+                case KnownSystem.SonyPlayStation4:
+                    Process sgraw = new Process()
+                    {
+                        StartInfo = new ProcessStartInfo()
+                        {
+                            FileName = "sg_raw.exe", // TODO: Make this configurable
+                            Arguments = "-v -r 4100 -R " + driveLetter + ": " + "ad 01 00 00 00 00 00 00 10 04 00 00 -o \"PIC.bin\""
+                        },
+                    };
+                    sgraw.Start();
+                    sgraw.WaitForExit();
+                    break;
+                case KnownSystem.SonyPlayStation:
+                    // TODO: Direct invocation of program instead of via Batch File
+                    using (StreamWriter writetext = new StreamWriter("PSX" + guid + ".bat"))
+                    {
+                        writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + ".bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z1.txt");
+                        writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 1).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z2.txt");
+                        writetext.WriteLine("psxt001z" + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 01).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z3.txt");
+                        writetext.WriteLine("psxt001z" + " " + "--libcrypt " + "\"" + outputDirectory + "\\" + outputFileName + ".sub\" > " + "\"" + outputDirectory + "\\" + "libcrypt.txt");
+                        writetext.WriteLine("psxt001z" + " " + "--libcryptdrvfast " + driveLetter + " > " + "\"" + outputDirectory + "\\" + "libcryptdrv.log");
+                    }
+                    Process psxt = new Process();
+                    psxt.StartInfo.FileName = "PSX" + guid + ".bat";
+                    psxt.Start();
+                    psxt.WaitForExit();
                     break;
             }
 
-        }
-
-        private void cmb_DriveLetter_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
-        {
-            driveLetter = cmb_DriveLetter.SelectedValue.ToString().Substring(0, 1);
-            Console.WriteLine(driveLetter);
             btn_Start.IsEnabled = true;
-
         }
     }
 }

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -616,6 +616,7 @@ namespace DICUI
         /// </remarks>
         public static List<Tuple<char, string>> CreateListOfDrives()
         {
+            // TODO: Floppy drives show up as DriveType.Removable, but so do USB drives, 
             return DriveInfo.GetDrives()
                 .Where(d => d.DriveType == DriveType.CDRom && d.IsReady)
                 .Select(d => new Tuple<char, string>(d.Name[0], d.VolumeLabel))

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace DICUI
 {
@@ -521,7 +523,7 @@ namespace DICUI
         /// <summary>
         /// Create a list of systems matched to their respective enums
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Systems matched to enums, if possible</returns>
         /// <remarks>
         /// This returns a List of Tuples whose structure is as follows:
         ///		Item 1: Printable name
@@ -578,6 +580,23 @@ namespace DICUI
             }
 
             return mapping;
+        }
+
+        /// <summary>
+        /// Create a list of active optical drives matched to their volume labels
+        /// </summary>
+        /// <returns>Active drives, matched to labels, if possible</returns>
+        /// <remarks>
+        /// This returns a List of Tuples whose structure is as follows:
+        ///		Item 1: Drive letter
+        ///		Item 2: Volume label
+        /// </remarks>
+        public static List<Tuple<char, string>> CreateListOfDrives()
+        {
+            return DriveInfo.GetDrives()
+                .Where(d => d.DriveType == DriveType.CDRom && d.IsReady)
+                .Select(d => new Tuple<char, string>(d.Name[0], d.VolumeLabel))
+                .ToList();
         }
     }
 }

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -422,7 +422,6 @@ namespace DICUI
                 case DiscType.GDROM:
                     return "gd"; // TODO: "swap"?
                 case DiscType.HDDVD:
-                    Console.WriteLine("HD-DVD dumping is not supported by DIC");
                     return null;
                 case DiscType.BD25:
                     return "bd";
@@ -433,7 +432,6 @@ namespace DICUI
                 case DiscType.GameCubeGameDisc:
                     return "dvd";
                 case DiscType.UMD:
-                    Console.WriteLine("UMD dumping is not supported by DIC");
                     return null;
 
                 // Non-optical
@@ -457,7 +455,6 @@ namespace DICUI
             List<DiscType?> validTypes = GetValidDiscTypes(sys);
             if (!validTypes.Contains(type))
             {
-                Console.WriteLine("Invalid DiscType '{0}' for System '{1}'", type.ToString(), KnownSystemToString(sys));
                 return null;
             }
 
@@ -494,7 +491,6 @@ namespace DICUI
                     parameters.Add("/c2 20");
                     break;
                 case DiscType.HDDVD:
-                    Console.WriteLine("HD-DVD dumping is not supported by DIC");
                     break;
                 case DiscType.BD25:
                     // Currently no defaults set
@@ -508,7 +504,6 @@ namespace DICUI
                     parameters.Add("/raw");
                     break;
                 case DiscType.UMD:
-                    Console.WriteLine("UMD dumping is not supported by DIC");
                     break;
 
                 // Non-optical

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -516,6 +516,34 @@ namespace DICUI
         }
 
         /// <summary>
+        /// Get the default extension for a given disc type
+        /// </summary>
+        /// <param name="type">DiscType value to check</param>
+        /// <returns>Valid extension (with leading '.'), null on error</returns>
+        public static string GetDefaultExtension(DiscType? type)
+        {
+            switch(type)
+            {
+                case DiscType.CD:
+                case DiscType.GDROM:
+                    return ".bin";
+                case DiscType.DVD5:
+                case DiscType.DVD9:
+                case DiscType.HDDVD:
+                case DiscType.BD25:
+                case DiscType.BD50:
+                case DiscType.GameCubeGameDisc:
+                case DiscType.UMD:
+                    return ".iso";
+                case DiscType.Floppy:
+                    return ".img";
+                case DiscType.NONE:
+                default:
+                    return null;
+            }
+        }
+
+        /// <summary>
         /// Create a list of systems matched to their respective enums
         /// </summary>
         /// <returns>Systems matched to enums, if possible</returns>


### PR DESCRIPTION
This PR adds a bunch of generic cleanup that will allow for easier code addition in the future. This also adds the automatic population of the drive speed dropdown, similar to how the disc type is populated. This DOES remove the ability to put in a custom (non-standard) value, but it also reduces the amount of issues associated with such values.

Other changes include the removal of the creation of a single-line batch file with a direct invocation (or attempted invocation) of an external tool.

Edit: Okay, this change got massive. A lot of cleanup and error checking got added. I swear I'm done for this commit now.