### PR TITLE
Disc Information Framework

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -135,7 +135,7 @@ namespace DICUI
             // Local variables
             string driveLetter = cmb_DriveLetter.Text;
             string outputDirectory = txt_OutputDirectory.Text;
-            string outputFileName = txt_OutputFilename.Text;
+            string outputFilename = txt_OutputFilename.Text;
             int driveSpeed = (int)cmb_DriveSpeed.SelectedItem;
             btn_Start.IsEnabled = false;
 
@@ -165,12 +165,19 @@ namespace DICUI
                     process.StartInfo.FileName = dicPath;
                     process.StartInfo.Arguments = discType
                         + " " + driveLetter
-                        + " \"" + Path.Combine(outputDirectory, outputFileName) + "\" "
+                        + " \"" + Path.Combine(outputDirectory, outputFilename) + "\" "
                         + (selected.Item3 != DiscType.BD25 && selected.Item3 != DiscType.BD50 ? driveSpeed + " " : "")
                         + string.Join(" ", defaultParams);
                     process.Start();
                     process.WaitForExit();
                 });
+
+            // Check to make sure that the output had all the correct files
+            if (!Utilities.FoundAllFiles(outputDirectory, outputFilename))
+            {
+                lbl_Status.Content = "Error! Please check output directory as dump may be incomplete!";
+                return;
+            }
 
             // Special cases
             switch (selected.Item2)
@@ -179,7 +186,7 @@ namespace DICUI
                 case KnownSystem.SonyPlayStation4:
                     if (!File.Exists(sgRawPath))
                     {
-                        lbl_Status.Content = "Error! Could not find sg-raw!!";
+                        lbl_Status.Content = "Error! Could not find sg-raw!";
                         return;
                     }
 
@@ -205,8 +212,8 @@ namespace DICUI
                     string batchname = "PSX" + Guid.NewGuid() + ".bat";
                     using (StreamWriter writetext = new StreamWriter(batchname))
                     {
-                        writetext.WriteLine(psxtPath + " " + "\"" + Utilities.GetFirstTrack(outputDirectory, outputFileName) + "\" > " + "\"" + Path.Combine(outputDirectory, "psxt001z.txt"));
-                        writetext.WriteLine(psxtPath + " " + "--libcrypt " + "\"" + Path.Combine(outputDirectory, outputFileName + ".sub") + "\" > " + "\"" + Path.Combine(outputDirectory, "libcrypt.txt"));
+                        writetext.WriteLine(psxtPath + " " + "\"" + Utilities.GetFirstTrack(outputDirectory, outputFilename) + "\" > " + "\"" + Path.Combine(outputDirectory, "psxt001z.txt"));
+                        writetext.WriteLine(psxtPath + " " + "--libcrypt " + "\"" + Path.Combine(outputDirectory, outputFilename + ".sub") + "\" > " + "\"" + Path.Combine(outputDirectory, "libcrypt.txt"));
                         writetext.WriteLine(psxtPath + " " + "--libcryptdrvfast " + driveLetter + " > " + "\"" + Path.Combine(outputDirectory, "libcryptdrv.log"));
                     }
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -179,9 +179,6 @@ namespace DICUI
                 return;
             }
 
-            // TODO: UNUSED
-            Dictionary<string, string> templateValues = Utilities.ExtractOutputInformation(outputDirectory, outputFilename, selected.Item2, selected.Item3);
-
             // Special cases
             switch (selected.Item2)
             {
@@ -236,6 +233,9 @@ namespace DICUI
                     }
                     break;
             }
+
+            // TODO: UNUSED
+            Dictionary<string, string> templateValues = Utilities.ExtractOutputInformation(outputDirectory, outputFilename, selected.Item2, selected.Item3);
 
             btn_Start.IsEnabled = true;
         }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -208,29 +208,39 @@ namespace DICUI
                         return;
                     }
 
-                    // TODO: Direct invocation of program instead of via Batch File
-                    string batchname = "PSX" + Guid.NewGuid() + ".bat";
-                    using (StreamWriter writetext = new StreamWriter(batchname))
+                    // Invoke the program with all 3 configurations
+                    Process psxt001z = new Process()
                     {
-                        writetext.WriteLine(psxtPath + " " + "\"" + Utilities.GetFirstTrack(outputDirectory, outputFilename) + "\" > " + "\"" + Path.Combine(outputDirectory, "psxt001z.txt"));
-                        writetext.WriteLine(psxtPath + " " + "--libcrypt " + "\"" + Path.Combine(outputDirectory, outputFilename + ".sub") + "\" > " + "\"" + Path.Combine(outputDirectory, "libcrypt.txt"));
-                        writetext.WriteLine(psxtPath + " " + "--libcryptdrvfast " + driveLetter + " > " + "\"" + Path.Combine(outputDirectory, "libcryptdrv.log"));
-                    }
+                        StartInfo = new ProcessStartInfo()
+                        {
+                            FileName = psxtPath,
+                            Arguments = "\"" + Utilities.GetFirstTrack(outputDirectory, outputFilename) + "\" > " + "\"" + Path.Combine(outputDirectory, "psxt001z.txt"),
+                        },
+                    };
+                    psxt001z.Start();
+                    psxt001z.WaitForExit();
 
-                    Process psxt = new Process();
-                    psxt.StartInfo.FileName = batchname;
-                    psxt.Start();
-                    psxt.WaitForExit();
+                    psxt001z = new Process()
+                    {
+                        StartInfo = new ProcessStartInfo()
+                        {
+                            FileName = psxtPath,
+                            Arguments = "--libcrypt " + "\"" + Path.Combine(outputDirectory, outputFilename + ".sub") + "\" > " + "\"" + Path.Combine(outputDirectory, "libcrypt.txt"),
+                        },
+                    };
+                    psxt001z.Start();
+                    psxt001z.WaitForExit();
 
-                    // Now try to delete the batch file
-                    try
+                    psxt001z = new Process()
                     {
-                        File.Delete(batchname);
-                    }
-                    catch
-                    {
-                        // Right now, we don't care if the batch file can't be deleted
-                    }
+                        StartInfo = new ProcessStartInfo()
+                        {
+                            FileName = psxtPath,
+                            Arguments = "--libcryptdrvfast " + driveLetter + " > " + "\"" + Path.Combine(outputDirectory, "libcryptdrv.log"),
+                        },
+                    };
+                    psxt001z.Start();
+                    psxt001z.WaitForExit();
                     break;
             }
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -179,6 +179,9 @@ namespace DICUI
                 return;
             }
 
+            // TODO: UNUSED
+            Dictionary<string, string> templateValues = Utilities.ExtractOutputInformation(outputDirectory, outputFilename, selected.Item2, selected.Item3);
+
             // Special cases
             switch (selected.Item2)
             {

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -173,7 +173,7 @@ namespace DICUI
                 });
 
             // Check to make sure that the output had all the correct files
-            if (!Utilities.FoundAllFiles(outputDirectory, outputFilename))
+            if (!Utilities.FoundAllFiles(outputDirectory, outputFilename, selected.Item3))
             {
                 lbl_Status.Content = "Error! Please check output directory as dump may be incomplete!";
                 return;

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -205,9 +205,9 @@ namespace DICUI
                     string batchname = "PSX" + Guid.NewGuid() + ".bat";
                     using (StreamWriter writetext = new StreamWriter(batchname))
                     {
-                        writetext.WriteLine(psxtPath + " " + "\"" + Utilities.GetFirstTrack(outputDirectory, outputFileName) + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z1.txt");
-                        writetext.WriteLine(psxtPath + " " + "--libcrypt " + "\"" + outputDirectory + "\\" + outputFileName + ".sub\" > " + "\"" + outputDirectory + "\\" + "libcrypt.txt");
-                        writetext.WriteLine(psxtPath + " " + "--libcryptdrvfast " + driveLetter + " > " + "\"" + outputDirectory + "\\" + "libcryptdrv.log");
+                        writetext.WriteLine(psxtPath + " " + "\"" + Utilities.GetFirstTrack(outputDirectory, outputFileName) + "\" > " + "\"" + Path.Combine(outputDirectory, "psxt001z.txt"));
+                        writetext.WriteLine(psxtPath + " " + "--libcrypt " + "\"" + Path.Combine(outputDirectory, outputFileName + ".sub") + "\" > " + "\"" + Path.Combine(outputDirectory, "libcrypt.txt"));
+                        writetext.WriteLine(psxtPath + " " + "--libcryptdrvfast " + driveLetter + " > " + "\"" + Path.Combine(outputDirectory, "libcryptdrv.log"));
                     }
 
                     Process psxt = new Process();

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -205,9 +205,7 @@ namespace DICUI
                     string batchname = "PSX" + Guid.NewGuid() + ".bat";
                     using (StreamWriter writetext = new StreamWriter(batchname))
                     {
-                        writetext.WriteLine(psxtPath + " " + "\"" + outputDirectory + "\\" + outputFileName + ".bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z1.txt");
-                        writetext.WriteLine(psxtPath + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 1).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z2.txt");
-                        writetext.WriteLine(psxtPath + " " + "\"" + outputDirectory + "\\" + outputFileName + " (Track 01).bin" + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z3.txt");
+                        writetext.WriteLine(psxtPath + " " + "\"" + Utilities.GetFirstTrack(outputDirectory, outputFileName) + "\" > " + "\"" + outputDirectory + "\\" + "psxt001z1.txt");
                         writetext.WriteLine(psxtPath + " " + "--libcrypt " + "\"" + outputDirectory + "\\" + outputFileName + ".sub\" > " + "\"" + outputDirectory + "\\" + "libcrypt.txt");
                         writetext.WriteLine(psxtPath + " " + "--libcryptdrvfast " + driveLetter + " > " + "\"" + outputDirectory + "\\" + "libcryptdrv.log");
                     }

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -622,5 +622,42 @@ namespace DICUI
                 .Select(d => new Tuple<char, string>(d.Name[0], d.VolumeLabel))
                 .ToList();
         }
+
+		/// <summary>
+		/// Attempts to find the first track of a dumped disc based on the inputs
+		/// </summary>
+		/// <param name="outputDirectory">Base directory to use</param>
+		/// <param name="outputFilename">Base filename to use</param>
+		/// <returns>Proper path to first track, null on error</returns>
+		/// <remarks>
+		/// By default, this assumes that the outputFilename doesn't contain a proper path, and just a name.
+		/// This can lead to a situation where the outputFilename contains a path, but only the filename gets
+		/// used in the processing and can lead to a "false null" return
+		/// </remarks>
+		public static string GetFirstTrack(string outputDirectory, string outputFilename)
+		{
+			// First, sanitized the output filename to strip off any potential extension
+			outputFilename = Path.GetFileNameWithoutExtension(outputFilename);
+
+			// Go through all standard output naming schemes
+			if (File.Exists(Path.Combine(outputDirectory, outputFilename + ".bin")))
+			{
+				return Path.Combine(outputDirectory, outputFilename + ".bin");
+			}
+			if (File.Exists(Path.Combine(outputDirectory, outputFilename + " (Track 1).bin")))
+			{
+				return Path.Combine(outputDirectory, outputFilename + " (Track 1).bin");
+			}
+			if (File.Exists(Path.Combine(outputDirectory, outputFilename + " (Track 01).bin")))
+			{
+				return Path.Combine(outputDirectory, outputFilename + " (Track 01).bin");
+			}
+			if (File.Exists(Path.Combine(outputDirectory, outputFilename + ".iso")))
+			{
+				return Path.Combine(outputDirectory, outputFilename + ".iso");
+			}
+
+			return null;
+		}
     }
 }

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -728,6 +728,7 @@ namespace DICUI
         /// <param name="sys">KnownSystem value to check</param>
         /// <param name="type">DiscType value to check</param>
         /// <returns>Dictionary containing mapped output values, null on error</returns>
+        /// <remarks>TODO: Make sure that all special formats are accounted for</remarks>
         public static Dictionary<string, string> ExtractOutputInformation(string outputDirectory, string outputFilename, KnownSystem? sys, DiscType? type)
         {
             // First, sanitized the output filename to strip off any potential extension
@@ -764,7 +765,7 @@ namespace DICUI
             // Now we want to do a check by DiscType and extract all required info
             switch (type)
             {
-                case DiscType.CD:
+                case DiscType.CD: // TODO: Add SecuROM data, but only if found
                 case DiscType.GDROM: // TODO: Verify GD-ROM outputs this
                     mappings["Mastering Ring"] = "";
                     mappings["Mastering SID Code"] = "";
@@ -776,6 +777,25 @@ namespace DICUI
                         combinedBase + "_mainError.txt").ToString();
                     mappings["Cuesheet"] = GetCuesheet(combinedBase + ".cue");
                     mappings["Write Offset"] = GetWriteOffset(combinedBase + "_disc.txt");
+
+                    // System-specific options
+                    switch (sys)
+                    {
+                        case KnownSystem.SegaSaturn:
+                            mappings["Header"] = ""; // GetSaturnHeader(GetFirstTrack(outputDirectory, outputFilename));
+                            mappings["Build Date"] = ""; //GetSaturnBuildDate(GetFirstTrack(outputDirectory, outputFilename));
+                            break;
+                        case KnownSystem.SonyPlayStation:
+                            mappings["EXE Date"] = ""; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
+                            mappings["EDC"] = "Yes/No";
+                            mappings["Anti-modchip"] = "Yes/No";
+                            mappings["LibCrypt"] = "Yes/No";
+                            break;
+                        case KnownSystem.SonyPlayStation2:
+                            mappings["EXE Date"] = ""; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
+                            break;
+                    }
+
                     break;
                 case DiscType.DVD5:
                 case DiscType.HDDVD:
@@ -785,6 +805,15 @@ namespace DICUI
                     mappings["Mould SID Code"] = "";
                     mappings["Additional Mould"] = "";
                     mappings["Toolstamp or Mastering Code"] = "";
+
+                    // System-specific options
+                    switch (sys)
+                    {
+                        case KnownSystem.SonyPlayStation2:
+                            mappings["EXE Date"] = ""; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
+                            break;
+                    }
+
                     break;
                 case DiscType.DVD9:
                 case DiscType.BD50:
@@ -797,6 +826,15 @@ namespace DICUI
                     mappings["Outer Toolstamp or Mastering Code"] = "";
                     mappings["Inner Toolstamp or Mastering Code"] = "";
                     mappings["Layerbreak"] = GetLayerbreak(combinedBase + "_disc.txt");
+
+                    // System-specific options
+                    switch (sys)
+                    {
+                        case KnownSystem.SonyPlayStation2:
+                            mappings["EXE Date"] = ""; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
+                            break;
+                    }
+
                     break;
                 case DiscType.GameCubeGameDisc:
                 case DiscType.UMD:

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -750,11 +750,6 @@ namespace DICUI
                 { "Region", "World (CHANGE THIS)" },
                 { "Languages", "Klingon (CHANGE THIS)" },
                 { "Disc Serial", "(OPTIONAL)" },
-                { "Mastering Ring", "" },
-                { "Mastering SID Code", "" },
-                { "Mould SID Code", "" },
-                { "Additional Mould", "" },
-                { "Toolstamp or Mastering Code", "" },
                 { "Barcode", "" },
                 { "ISBN", "" },
                 { "Comments", "(OPTIONAL)" },
@@ -771,8 +766,12 @@ namespace DICUI
             {
                 case DiscType.CD:
                 case DiscType.GDROM: // TODO: Verify GD-ROM outputs this
+                    mappings["Mastering Ring"] = "";
+                    mappings["Mastering SID Code"] = "";
+                    mappings["Mould SID Code"] = "";
+                    mappings["Additional Mould"] = "";
+                    mappings["Toolstamp or Mastering Code"] = "";
                     mappings["Write Offset"] = "";
-
                     mappings["Error Count"] = GetErrorCount(combinedBase + ".img_EdcEcc.txt",
                         combinedBase + "_c2Error.txt",
                         combinedBase + "_mainError.txt").ToString();
@@ -781,13 +780,26 @@ namespace DICUI
                 case DiscType.DVD5:
                 case DiscType.HDDVD:
                 case DiscType.BD25:
-                case DiscType.GameCubeGameDisc:
-                case DiscType.UMD:
+                    mappings["Mastering Ring"] = "";
+                    mappings["Mastering SID Code"] = "";
+                    mappings["Mould SID Code"] = "";
+                    mappings["Additional Mould"] = "";
+                    mappings["Toolstamp or Mastering Code"] = "";
                     break;
                 case DiscType.DVD9:
                 case DiscType.BD50:
+                    mappings["Outer Mastering Ring"] = "";
+                    mappings["Inner Mastering Ring"] = "";
+                    mappings["Outer Mastering SID Code"] = "";
+                    mappings["Inner Mastering SID Code"] = "";
+                    mappings["Mould SID Code"] = "";
+                    mappings["Additional Mould"] = "";
+                    mappings["Outer Toolstamp or Mastering Code"] = "";
+                    mappings["Inner Toolstamp or Mastering Code"] = "";
                     mappings["Layerbreak"] = "(REQUIRED)";
                     break;
+                case DiscType.GameCubeGameDisc:
+                case DiscType.UMD:
                 case DiscType.Floppy:
                 default:
                     // No-op
@@ -842,12 +854,15 @@ namespace DICUI
 
                     // Fast forward to the rom lines
                     while (!sr.ReadLine().TrimStart().StartsWith("<game")) ;
+                    sr.ReadLine(); // <category>Games</category>
+                    sr.ReadLine(); // <description>Plextor</description>
 
                     // Now that we're at the relevant entries, read each line in and concatenate
                     string pvd = "", line = sr.ReadLine().Trim();
                     while (line.StartsWith("<rom"))
                     {
                         pvd += line + "\n";
+                        line = sr.ReadLine().Trim();
                     }
 
                     return pvd.TrimEnd('\n');

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -5,6 +5,7 @@ using System.Linq;
 
 namespace DICUI
 {
+	// TODO: Separate into different utility classes based on functionality
     public static class Utilities
     {
         /// <summary>

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -623,41 +623,94 @@ namespace DICUI
                 .ToList();
         }
 
-		/// <summary>
-		/// Attempts to find the first track of a dumped disc based on the inputs
-		/// </summary>
-		/// <param name="outputDirectory">Base directory to use</param>
-		/// <param name="outputFilename">Base filename to use</param>
-		/// <returns>Proper path to first track, null on error</returns>
-		/// <remarks>
-		/// By default, this assumes that the outputFilename doesn't contain a proper path, and just a name.
-		/// This can lead to a situation where the outputFilename contains a path, but only the filename gets
-		/// used in the processing and can lead to a "false null" return
-		/// </remarks>
-		public static string GetFirstTrack(string outputDirectory, string outputFilename)
-		{
-			// First, sanitized the output filename to strip off any potential extension
-			outputFilename = Path.GetFileNameWithoutExtension(outputFilename);
+        /// <summary>
+        /// Attempts to find the first track of a dumped disc based on the inputs
+        /// </summary>
+        /// <param name="outputDirectory">Base directory to use</param>
+        /// <param name="outputFilename">Base filename to use</param>
+        /// <returns>Proper path to first track, null on error</returns>
+        /// <remarks>
+        /// By default, this assumes that the outputFilename doesn't contain a proper path, and just a name.
+        /// This can lead to a situation where the outputFilename contains a path, but only the filename gets
+        /// used in the processing and can lead to a "false null" return
+        /// </remarks>
+        public static string GetFirstTrack(string outputDirectory, string outputFilename)
+        {
+            // First, sanitized the output filename to strip off any potential extension
+            outputFilename = Path.GetFileNameWithoutExtension(outputFilename);
 
-			// Go through all standard output naming schemes
-			if (File.Exists(Path.Combine(outputDirectory, outputFilename + ".bin")))
-			{
-				return Path.Combine(outputDirectory, outputFilename + ".bin");
-			}
-			if (File.Exists(Path.Combine(outputDirectory, outputFilename + " (Track 1).bin")))
-			{
-				return Path.Combine(outputDirectory, outputFilename + " (Track 1).bin");
-			}
-			if (File.Exists(Path.Combine(outputDirectory, outputFilename + " (Track 01).bin")))
-			{
-				return Path.Combine(outputDirectory, outputFilename + " (Track 01).bin");
-			}
-			if (File.Exists(Path.Combine(outputDirectory, outputFilename + ".iso")))
-			{
-				return Path.Combine(outputDirectory, outputFilename + ".iso");
-			}
+            // Go through all standard output naming schemes
+            string combinedBase = Path.Combine(outputDirectory, outputFilename);
+            if (File.Exists(combinedBase + ".bin"))
+            {
+                return combinedBase + ".bin";
+            }
+            if (File.Exists(combinedBase + " (Track 1).bin"))
+            {
+                return combinedBase + " (Track 1).bin";
+            }
+            if (File.Exists(combinedBase + " (Track 01).bin"))
+            {
+                return combinedBase + " (Track 01).bin";
+            }
+            if (File.Exists(combinedBase + ".iso"))
+            {
+                return Path.Combine(combinedBase + ".iso");
+            }
 
-			return null;
-		}
+            return null;
+        }
+
+        /// <summary>
+        /// Ensures that all required output files have been created
+        /// </summary>
+        /// <param name="outputDirectory">Base directory to use</param>
+        /// <param name="outputFilename">Base filename to use</param>
+        /// <returns></returns>
+        public static bool FoundAllFiles(string outputDirectory, string outputFilename)
+        {
+            // First, sanitized the output filename to strip off any potential extension
+            outputFilename = Path.GetFileNameWithoutExtension(outputFilename);
+
+            // Check to see what type of files we should be expecting
+            string ext = Path.GetExtension(GetFirstTrack(outputDirectory, outputFilename)).TrimStart('.');
+
+            // Now ensure that all required files exist
+            string combinedBase = Path.Combine(outputDirectory, outputFilename);
+            switch(ext)
+            {
+                case "bin":
+                    return File.Exists(combinedBase + ".c2")
+                        && File.Exists(combinedBase + ".ccd")
+                        && File.Exists(combinedBase + ".cue")
+                        && File.Exists(combinedBase + ".dat")
+                        && File.Exists(combinedBase + ".img")
+                        && File.Exists(combinedBase + ".img_EdcEcc.txt")
+                        && File.Exists(combinedBase + ".scm")
+                        && File.Exists(combinedBase + ".sub")
+                        && File.Exists(combinedBase + "_c2Error.txt")
+                        && File.Exists(combinedBase + "_cmd.txt")
+                        && File.Exists(combinedBase + "_disc.txt")
+                        && File.Exists(combinedBase + "_drive.txt")
+                        && File.Exists(combinedBase + "_img.cue")
+                        && File.Exists(combinedBase + "_mainError.txt")
+                        && File.Exists(combinedBase + "_mainInfo.txt")
+                        && File.Exists(combinedBase + "_subError.txt")
+                        && File.Exists(combinedBase + "_subInfo.txt")
+                        && File.Exists(combinedBase + "_subIntention.txt")
+                        && File.Exists(combinedBase + "_subReadable.txt")
+                        && File.Exists(combinedBase + "_volDesc.txt");
+                case "iso":
+                    return File.Exists(combinedBase + ".dat")
+                        && File.Exists(combinedBase + "_cmd.txt")
+                        && File.Exists(combinedBase + "_disc.txt")
+                        && File.Exists(combinedBase + "_drive.txt")
+                        && File.Exists(combinedBase + "_mainError.txt")
+                        && File.Exists(combinedBase + "_mainInfo.txt")
+                        && File.Exists(combinedBase + "_volDesc.txt");
+                default:
+                    return false;
+            }
+        }
     }
 }

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -796,7 +796,7 @@ namespace DICUI
                     mappings["Additional Mould"] = "";
                     mappings["Outer Toolstamp or Mastering Code"] = "";
                     mappings["Inner Toolstamp or Mastering Code"] = "";
-                    mappings["Layerbreak"] = "(REQUIRED)";
+                    mappings["Layerbreak"] = GetLayerbreak(combinedBase + "_disc.txt");
                     break;
                 case DiscType.GameCubeGameDisc:
                 case DiscType.UMD:
@@ -932,6 +932,43 @@ namespace DICUI
                 {
                     // We don't care what the exception is right now
                     return -1;
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Get the layerbreak from the input file, if possible
+        /// </summary>
+        /// <param name="disc">_disc.txt file location</param>
+        /// <returns>Layerbreak if possible, null on error</returns>
+        private static string GetLayerbreak(string disc)
+        {
+            // If the file doesn't exist, we can't get info from it
+            if (!File.Exists(disc))
+            {
+                return null;
+            }
+
+            using (StreamReader sr = File.OpenText(disc))
+            {
+                try
+                {
+                    // Make sure this file is a _disc.txt
+                    if (sr.ReadLine() != "========== DiscStructure ==========")
+                    {
+                        return null;
+                    }
+
+                    // Fast forward to the layerbreak
+                    while (!sr.ReadLine().Trim().StartsWith("EndDataSector")) ;
+
+                    // Now that we're at the layerbreak line, attempt to get the decimal version
+                    return sr.ReadLine().Split(' ')[1];
+                }
+                catch
+                {
+                    // We don't care what the exception is right now
+                    return null;
                 }
             }
         }


### PR DESCRIPTION
Provide a basic framework for getting all required disc information in one place.

Currently, this is not practically hooked up (just a Dictionary is populated), but in a future PR, this will result in an outputted file with all of the information correctly formatted.

Known issues with this commit:
- Not all error counts (and warning counts) are correctly detected
- Missing values are not handled gracefully (usually just set to null)
- The Utilities class is starting to get bloated with too much disparate stuff