### PR TITLE
Write Centralized Disc Information

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -1,42 +1,48 @@
 ﻿namespace DICUI
 {
-	public static class Constants
-	{
-		// Manual information
+    public static class Constants
+    {
+        // Manual information
 
-		public const string TitleField = "Title";
-		public const string DiscNumberField = "Disc Number / Letter";
-		public const string DiscTitleField = "Disc Title";
-		public const string CategoryField = "Category";
-		public const string RegionField = "Region";
-		public const string LanguagesField = "Languages";
-		public const string DiscSerialField = "Disc Serial";
-		public const string BarcodeField = "Barcode";
-		public const string ISBNField = "ISBN";
-		public const string CommentsField = "Comments";
-		public const string ContentsField = "Contents";
-		public const string VersionField = "Version";
-		public const string EditionField = "Edition/Release";
-		public const string CopyProtectionField = "Copy Protection";
-		public const string MasteringRingField = "Mastering Ring";
-		public const string MasteringSIDField = "Mastering SID Code";
-		public const string MouldSIDField = "Mould SID Code";
-		public const string AdditionalMouldField = "Additional Mould";
-		public const string ToolstampField = "Toolstamp or Mastering Code";
+        public const string TitleField = "Title";
+        public const string DiscNumberField = "Disc Number / Letter";
+        public const string DiscTitleField = "Disc Title";
+        public const string CategoryField = "Category";
+        public const string RegionField = "Region";
+        public const string LanguagesField = "Languages";
+        public const string DiscSerialField = "Disc Serial";
+        public const string BarcodeField = "Barcode";
+        public const string ISBNField = "ISBN";
+        public const string CommentsField = "Comments";
+        public const string ContentsField = "Contents";
+        public const string VersionField = "Version";
+        public const string EditionField = "Edition/Release";
+        public const string CopyProtectionField = "Copy Protection";
+        public const string MasteringRingField = "Mastering Ring";
+        public const string MasteringSIDField = "Mastering SID Code";
+        public const string MouldSIDField = "Mould SID Code";
+        public const string AdditionalMouldField = "Additional Mould";
+        public const string ToolstampField = "Toolstamp or Mastering Code";
 
-		// Automatic Information
+        // Automatic Information
 
-		public const string PVDField = "Primary Volume Descriptor (PVD)";
-		public const string DATField = "DAT";
-		public const string ErrorCountField = "Error Count";
-		public const string CuesheetField = "Cuesheet";
-		public const string WriteOffsetField = "WriteOffset";
-		public const string LayerbreakField = "Layerbreak";
-		public const string PlaystationEXEDateField = "EXE Date"; // TODO: Not automatic yet
-		public const string PlayStationEDCField = "EDC"; // TODO: Not automatic yet
-		public const string PlayStationAntiModchipField = "Anti-modchip"; // TODO: Not automatic yet
-		public const string PlayStationLibCryptField = "LibCrypt"; // TODO: Not automatic yet
-		public const string SaturnHeaderField = "Header"; // TODO: Not automatic yet
-		public const string SaturnBuildDateField = "Build Date"; // TODO: Not automatic yet
-	}
+        public const string PVDField = "Primary Volume Descriptor (PVD)";
+        public const string DATField = "DAT";
+        public const string ErrorCountField = "Error Count";
+        public const string CuesheetField = "Cuesheet";
+        public const string WriteOffsetField = "WriteOffset";
+        public const string LayerbreakField = "Layerbreak";
+        public const string PlaystationEXEDateField = "EXE Date"; // TODO: Not automatic yet
+        public const string PlayStationEDCField = "EDC"; // TODO: Not automatic yet
+        public const string PlayStationAntiModchipField = "Anti-modchip"; // TODO: Not automatic yet
+        public const string PlayStationLibCryptField = "LibCrypt"; // TODO: Not automatic yet
+        public const string SaturnHeaderField = "Header"; // TODO: Not automatic yet
+        public const string SaturnBuildDateField = "Build Date"; // TODO: Not automatic yet
+
+        // Default values
+        public const string RequiredValue = "(REQUIRED)";
+        public const string RequiredIfExistsValue = "(REQUIRED, IF EXISTS)";
+        public const string OptionalValue = "(OPTIONAL)";
+        public const string YesNoValue = "Yes/No";
+    }
 }

--- a/Constants.cs
+++ b/Constants.cs
@@ -1,0 +1,42 @@
+﻿namespace DICUI
+{
+	public static class Constants
+	{
+		// Manual information
+
+		public const string TitleField = "Title";
+		public const string DiscNumberField = "Disc Number / Letter";
+		public const string DiscTitleField = "Disc Title";
+		public const string CategoryField = "Category";
+		public const string RegionField = "Region";
+		public const string LanguagesField = "Languages";
+		public const string DiscSerialField = "Disc Serial";
+		public const string BarcodeField = "Barcode";
+		public const string ISBNField = "ISBN";
+		public const string CommentsField = "Comments";
+		public const string ContentsField = "Contents";
+		public const string VersionField = "Version";
+		public const string EditionField = "Edition/Release";
+		public const string CopyProtectionField = "Copy Protection";
+		public const string MasteringRingField = "Mastering Ring";
+		public const string MasteringSIDField = "Mastering SID Code";
+		public const string MouldSIDField = "Mould SID Code";
+		public const string AdditionalMouldField = "Additional Mould";
+		public const string ToolstampField = "Toolstamp or Mastering Code";
+
+		// Automatic Information
+
+		public const string PVDField = "Primary Volume Descriptor (PVD)";
+		public const string DATField = "DAT";
+		public const string ErrorCountField = "Error Count";
+		public const string CuesheetField = "Cuesheet";
+		public const string WriteOffsetField = "WriteOffset";
+		public const string LayerbreakField = "Layerbreak";
+		public const string PlaystationEXEDateField = "EXE Date"; // TODO: Not automatic yet
+		public const string PlayStationEDCField = "EDC"; // TODO: Not automatic yet
+		public const string PlayStationAntiModchipField = "Anti-modchip"; // TODO: Not automatic yet
+		public const string PlayStationLibCryptField = "LibCrypt"; // TODO: Not automatic yet
+		public const string SaturnHeaderField = "Header"; // TODO: Not automatic yet
+		public const string SaturnBuildDateField = "Build Date"; // TODO: Not automatic yet
+	}
+}

--- a/DICUI.csproj
+++ b/DICUI.csproj
@@ -87,6 +87,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Constants.cs" />
     <Compile Include="Utilities.cs" />
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -209,6 +209,7 @@ namespace DICUI
                     }
 
                     // Invoke the program with all 3 configurations
+                    // TODO: Use these outputs for PSX information
                     Process psxt001z = new Process()
                     {
                         StartInfo = new ProcessStartInfo()
@@ -244,8 +245,9 @@ namespace DICUI
                     break;
             }
 
-            // TODO: UNUSED
             Dictionary<string, string> templateValues = Utilities.ExtractOutputInformation(outputDirectory, outputFilename, selected.Item2, selected.Item3);
+            List<string> formattedValues = Utilities.FormatOutputData(templateValues, selected.Item2, selected.Item3);
+            bool success = Utilities.WriteOutputData(formattedValues);
 
             btn_Start.IsEnabled = true;
         }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -158,6 +158,7 @@ namespace DICUI
                 return;
             }
 
+            lbl_Status.Content = "Beginning dumping process";
             await Task.Run(
                 () =>
                 {
@@ -171,13 +172,6 @@ namespace DICUI
                     process.Start();
                     process.WaitForExit();
                 });
-
-            // Check to make sure that the output had all the correct files
-            if (!Utilities.FoundAllFiles(outputDirectory, outputFilename, selected.Item3))
-            {
-                lbl_Status.Content = "Error! Please check output directory as dump may be incomplete!";
-                return;
-            }
 
             // Special cases
             switch (selected.Item2)
@@ -244,6 +238,15 @@ namespace DICUI
                     psxt001z.WaitForExit();
                     break;
             }
+
+            // Check to make sure that the output had all the correct files
+            if (!Utilities.FoundAllFiles(outputDirectory, outputFilename, selected.Item3))
+            {
+                lbl_Status.Content = "Error! Please check output directory as dump may be incomplete!";
+                return;
+            }
+
+            lbl_Status.Content = "Dumping complete!";
 
             Dictionary<string, string> templateValues = Utilities.ExtractOutputInformation(outputDirectory, outputFilename, selected.Item2, selected.Item3);
             List<string> formattedValues = Utilities.FormatOutputData(templateValues, selected.Item2, selected.Item3);

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -247,7 +247,7 @@ namespace DICUI
 
             Dictionary<string, string> templateValues = Utilities.ExtractOutputInformation(outputDirectory, outputFilename, selected.Item2, selected.Item3);
             List<string> formattedValues = Utilities.FormatOutputData(templateValues, selected.Item2, selected.Item3);
-            bool success = Utilities.WriteOutputData(formattedValues);
+            bool success = Utilities.WriteOutputData(outputDirectory, outputFilename, formattedValues);
 
             btn_Start.IsEnabled = true;
         }

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -1158,8 +1158,8 @@ namespace DICUI
                         output.Add("Inner " + Constants.ToolstampField + ": " + info["Inner " + Constants.ToolstampField]);
                         break;
                 }
-                output.Add(info[Constants.BarcodeField]);
-                output.Add(info[Constants.ISBNField]);
+                output.Add(info[Constants.BarcodeField + ": " + Constants.BarcodeField]);
+                output.Add(info[Constants.ISBNField + ": " + Constants.ISBNField]);
                 switch (type)
                 {
                     case DiscType.CD:
@@ -1184,7 +1184,7 @@ namespace DICUI
                         break;
                 }
                 output.Add(Constants.PVDField + ":"); output.Add("");
-                output.AddRange(info[Constants.PVDField].Split('\n')); output.Add("");
+                output.AddRange(info[Constants.PVDField].Split('\n'));
                 switch (sys)
                 {
                     case KnownSystem.AppleMacintosh:
@@ -1203,7 +1203,7 @@ namespace DICUI
                         break;
                 }
                 output.Add(Constants.DATField + ":"); output.Add("");
-                output.AddRange(info[Constants.DATField].Split('\n')); output.Add("");
+                output.AddRange(info[Constants.DATField].Split('\n'));
 
                 return output;
             }

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -1213,5 +1213,38 @@ namespace DICUI
                 return null;
             }
         }
+
+        /// <summary>
+        /// Write the data to the output folder
+        /// </summary>
+        /// <param name="outputDirectory">Base directory to use</param>
+        /// <param name="outputFilename">Base filename to use</param>
+        /// <param name="lines">Preformatted list of lines to write out to the file</param>
+        /// <returns>True on success, false on error</returns>
+        public static bool WriteOutputData(string outputDirectory, string outputFilename, List<string> lines)
+        {
+            // First, sanitized the output filename to strip off any potential extension
+            outputFilename = Path.GetFileNameWithoutExtension(outputFilename);
+
+            // Now write out to a generic file
+            string combinedBase = Path.Combine(outputDirectory, outputFilename);
+            try
+            {
+                using (StreamWriter sw = new StreamWriter(File.OpenWrite(combinedBase + ".txt")))
+                {
+                    foreach (string line in lines)
+                    {
+                        sw.WriteLine(line);
+                    }
+                }
+            }
+            catch
+            {
+                // We don't care what the error is right now
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -744,22 +744,23 @@ namespace DICUI
             string combinedBase = Path.Combine(outputDirectory, outputFilename);
             Dictionary<string, string> mappings = new Dictionary<string, string>
             {
-                { "Title", "(REQUIRED)" },
-                { "Disc Number / Letter", "(OPTIONAL)" },
-                { "Disc Title", "(OPTIONAL)" },
-                { "Category", "Games" },
-                { "Region", "World (CHANGE THIS)" },
-                { "Languages", "Klingon (CHANGE THIS)" },
-                { "Disc Serial", "(OPTIONAL)" },
-                { "Barcode", "" },
-                { "ISBN", "" },
-                { "Comments", "(OPTIONAL)" },
-                { "Contents", "(OPTIONAL)" },
-                { "Version", "" },
-                { "Edition/Release", "Original (VERIFY THIS)" },
-                { "Primary Volume Descriptor (PVD)", GetPVD(combinedBase + "_mainInfo.txt") },
-                { "Copy Protection", "(REQUIRED, IF EXISTS)" },
-                { "DAT", GetDatfile(combinedBase + ".dat") },
+                { Constants.TitleField, "(REQUIRED)" },
+                { Constants.DiscNumberField, "(OPTIONAL)" },
+                { Constants.DiscTitleField, "(OPTIONAL)" },
+                { Constants.CategoryField, "Games" },
+                { Constants.RegionField, "World (CHANGE THIS)" },
+                { Constants.LanguagesField, "Klingon (CHANGE THIS)" },
+                { Constants.DiscSerialField, "(OPTIONAL)" },
+                { Constants.MouldSIDField, "" },
+                { Constants.AdditionalMouldField, "" },
+                { Constants.BarcodeField, "" },
+                { Constants.ISBNField, "" },
+                { Constants.CommentsField, "(OPTIONAL)" },
+                { Constants.ContentsField, "(OPTIONAL)" },
+                { Constants.VersionField, "" },
+                { Constants.EditionField, "Original (VERIFY THIS)" },
+                { Constants.PVDField, GetPVD(combinedBase + "_mainInfo.txt") },
+                { Constants.DATField, GetDatfile(combinedBase + ".dat") },
             };
 
             // Now we want to do a check by DiscType and extract all required info
@@ -767,32 +768,34 @@ namespace DICUI
             {
                 case DiscType.CD: // TODO: Add SecuROM data, but only if found
                 case DiscType.GDROM: // TODO: Verify GD-ROM outputs this
-                    mappings["Mastering Ring"] = "";
-                    mappings["Mastering SID Code"] = "";
-                    mappings["Mould SID Code"] = "";
-                    mappings["Additional Mould"] = "";
-                    mappings["Toolstamp or Mastering Code"] = "";
-                    mappings["Error Count"] = GetErrorCount(combinedBase + ".img_EdcEcc.txt",
+                    mappings[Constants.MasteringRingField] = "";
+                    mappings[Constants.MasteringSIDField] = "";
+                    mappings[Constants.ToolstampField] = "";
+                    mappings[Constants.ErrorCountField] = GetErrorCount(combinedBase + ".img_EdcEcc.txt",
                         combinedBase + "_c2Error.txt",
                         combinedBase + "_mainError.txt").ToString();
-                    mappings["Cuesheet"] = GetCuesheet(combinedBase + ".cue");
-                    mappings["Write Offset"] = GetWriteOffset(combinedBase + "_disc.txt");
+                    mappings[Constants.CuesheetField] = GetCuesheet(combinedBase + ".cue");
+                    mappings[Constants.WriteOffsetField] = GetWriteOffset(combinedBase + "_disc.txt");
 
                     // System-specific options
                     switch (sys)
                     {
+                        case KnownSystem.AppleMacintosh:
+                        case KnownSystem.IBMPCCompatible:
+                            mappings[Constants.CopyProtectionField] = "(REQUIRED, IF EXISTS)";
+                            break;
                         case KnownSystem.SegaSaturn:
-                            mappings["Header"] = ""; // GetSaturnHeader(GetFirstTrack(outputDirectory, outputFilename));
-                            mappings["Build Date"] = ""; //GetSaturnBuildDate(GetFirstTrack(outputDirectory, outputFilename));
+                            mappings[Constants.SaturnHeaderField] = ""; // GetSaturnHeader(GetFirstTrack(outputDirectory, outputFilename));
+                            mappings[Constants.SaturnBuildDateField] = ""; //GetSaturnBuildDate(GetFirstTrack(outputDirectory, outputFilename));
                             break;
                         case KnownSystem.SonyPlayStation:
-                            mappings["EXE Date"] = ""; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
-                            mappings["EDC"] = "Yes/No";
-                            mappings["Anti-modchip"] = "Yes/No";
-                            mappings["LibCrypt"] = "Yes/No";
+                            mappings[Constants.PlaystationEXEDateField] = ""; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
+                            mappings[Constants.PlayStationEDCField] = "Yes/No";
+                            mappings[Constants.PlayStationAntiModchipField] = "Yes/No";
+                            mappings[Constants.PlayStationLibCryptField] = "Yes/No";
                             break;
                         case KnownSystem.SonyPlayStation2:
-                            mappings["EXE Date"] = ""; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
+                            mappings[Constants.PlaystationEXEDateField] = ""; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
                             break;
                     }
 
@@ -800,47 +803,45 @@ namespace DICUI
                 case DiscType.DVD5:
                 case DiscType.HDDVD:
                 case DiscType.BD25:
-                    mappings["Mastering Ring"] = "";
-                    mappings["Mastering SID Code"] = "";
-                    mappings["Mould SID Code"] = "";
-                    mappings["Additional Mould"] = "";
-                    mappings["Toolstamp or Mastering Code"] = "";
+                    mappings[Constants.MasteringRingField] = "";
+                    mappings[Constants.MasteringSIDField] = "";
+                    mappings[Constants.ToolstampField] = "";
 
                     // System-specific options
                     switch (sys)
                     {
+                        case KnownSystem.AppleMacintosh:
+                        case KnownSystem.IBMPCCompatible:
+                            mappings[Constants.CopyProtectionField] = "(REQUIRED, IF EXISTS)";
+                            break;
                         case KnownSystem.SonyPlayStation2:
-                            mappings["EXE Date"] = ""; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
+                            mappings[Constants.PlaystationEXEDateField] = ""; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
                             break;
                     }
 
                     break;
                 case DiscType.DVD9:
                 case DiscType.BD50:
-                    mappings["Outer Mastering Ring"] = "";
-                    mappings["Inner Mastering Ring"] = "";
-                    mappings["Outer Mastering SID Code"] = "";
-                    mappings["Inner Mastering SID Code"] = "";
-                    mappings["Mould SID Code"] = "";
-                    mappings["Additional Mould"] = "";
-                    mappings["Outer Toolstamp or Mastering Code"] = "";
-                    mappings["Inner Toolstamp or Mastering Code"] = "";
-                    mappings["Layerbreak"] = GetLayerbreak(combinedBase + "_disc.txt");
+                    mappings["Outer " + Constants.MasteringRingField] = "";
+                    mappings["Inner " + Constants.MasteringRingField] = "";
+                    mappings["Outer " + Constants.MasteringSIDField] = "";
+                    mappings["Inner " + Constants.MasteringSIDField] = "";
+                    mappings["Outer " + Constants.ToolstampField] = "";
+                    mappings["Inner " + Constants.ToolstampField] = "";
+                    mappings[Constants.LayerbreakField] = GetLayerbreak(combinedBase + "_disc.txt");
 
                     // System-specific options
                     switch (sys)
                     {
+                        case KnownSystem.AppleMacintosh:
+                        case KnownSystem.IBMPCCompatible:
+                            mappings[Constants.CopyProtectionField] = "(REQUIRED, IF EXISTS)";
+                            break;
                         case KnownSystem.SonyPlayStation2:
-                            mappings["EXE Date"] = ""; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
+                            mappings[Constants.PlaystationEXEDateField] = ""; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
                             break;
                     }
 
-                    break;
-                case DiscType.GameCubeGameDisc:
-                case DiscType.UMD:
-                case DiscType.Floppy:
-                default:
-                    // No-op
                     break;
             }
 
@@ -1092,6 +1093,124 @@ namespace DICUI
                     // We don't care what the exception is right now
                     return null;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Format the output data in a human readable way, separating each printed line into a new item in the list
+        /// </summary>
+        /// <param name="info">Information dictionary that should contain normalized values</param>
+        /// <param name="sys">KnownSystem value to check</param>
+        /// <param name="type">DiscType value to check</param>
+        /// <returns>List of strings representing each line of an output file, null on error</returns>
+        /// <remarks>TODO: Get full list of customizable stuff for other systems</remarks>
+        public static List<string> FormatOutputData(Dictionary<string, string> info, KnownSystem? sys, DiscType? type)
+        {
+            // Check to see if the inputs are valid
+            if (info == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                List<string> output = new List<string>();
+
+                output.Add(Constants.TitleField + ": " + info[Constants.TitleField]);
+                output.Add(Constants.DiscNumberField + ": " + info[Constants.DiscNumberField]);
+                output.Add(Constants.DiscTitleField + ": " + info[Constants.DiscTitleField]);
+                output.Add(Constants.CategoryField + ": " + info[Constants.CategoryField]);
+                output.Add(Constants.RegionField + ": " + info[Constants.RegionField]);
+                output.Add(Constants.LanguagesField + ": " + info[Constants.LanguagesField]);
+                output.Add(Constants.DiscSerialField + ": " + info[Constants.DiscSerialField]);
+                switch(sys)
+                {
+                    case KnownSystem.SegaSaturn:
+                        output.Add(Constants.SaturnBuildDateField + ": " + info[Constants.SaturnBuildDateField]);
+                        break;
+                    case KnownSystem.SonyPlayStation:
+                    case KnownSystem.SonyPlayStation2:
+                        output.Add(Constants.PlaystationEXEDateField + ": " + info[Constants.PlaystationEXEDateField]);
+                        break;
+                }
+                switch (type)
+                {
+                    case DiscType.CD:
+                    case DiscType.GDROM:
+                    case DiscType.DVD5:
+                    case DiscType.HDDVD:
+                    case DiscType.BD25:
+                        output.Add(Constants.MasteringRingField + ": " + info[Constants.MasteringRingField]);
+                        output.Add(Constants.MasteringSIDField + ": " + info[Constants.MasteringSIDField]);
+                        output.Add(Constants.MouldSIDField + ": " + info[Constants.MouldSIDField]);
+                        output.Add(Constants.AdditionalMouldField + ": " + info[Constants.AdditionalMouldField]);
+                        output.Add(Constants.ToolstampField + ": " + info[Constants.ToolstampField]);
+                        break;
+                    case DiscType.DVD9:
+                    case DiscType.BD50:
+                        output.Add("Outer " + Constants.MasteringRingField + ": " + info["Outer " + Constants.MasteringRingField]);
+                        output.Add("Inner " + Constants.MasteringRingField + ": " + info["Inner " + Constants.MasteringRingField]);
+                        output.Add("Outer " + Constants.MasteringSIDField + ": " + info["Outer " + Constants.MasteringSIDField]);
+                        output.Add("Inner " + Constants.MasteringSIDField + ": " + info["Inner " + Constants.MasteringSIDField]);
+                        output.Add(Constants.MouldSIDField + ": " + info[Constants.MouldSIDField]);
+                        output.Add(Constants.AdditionalMouldField + ": " + info[Constants.AdditionalMouldField]);
+                        output.Add("Outer " + Constants.ToolstampField + ": " + info["Outer " + Constants.ToolstampField]);
+                        output.Add("Inner " + Constants.ToolstampField + ": " + info["Inner " + Constants.ToolstampField]);
+                        break;
+                }
+                output.Add(info[Constants.BarcodeField]);
+                output.Add(info[Constants.ISBNField]);
+                switch (type)
+                {
+                    case DiscType.CD:
+                    case DiscType.GDROM:
+                        output.Add(Constants.ErrorCountField + ": " + info[Constants.ErrorCountField]);
+                        break;
+                }
+                output.Add(Constants.CommentsField + ": " + info[Constants.CommentsField]);
+                output.Add(Constants.ContentsField + ": " + info[Constants.ContentsField]);
+                output.Add(Constants.VersionField + ": " + info[Constants.VersionField]);
+                output.Add(Constants.EditionField + ": " + info[Constants.EditionField]);
+                switch (sys)
+                {
+                    case KnownSystem.SegaSaturn:
+                        output.Add(Constants.SaturnHeaderField + ":"); output.Add("");
+                        output.AddRange(info[Constants.SaturnHeaderField].Split('\n')); output.Add("");
+                        break;
+                    case KnownSystem.SonyPlayStation:
+                        output.Add(Constants.PlayStationEDCField + ": " + info[Constants.PlayStationEDCField]);
+                        output.Add(Constants.PlayStationAntiModchipField + ": " + info[Constants.PlayStationAntiModchipField]);
+                        output.Add(Constants.PlayStationLibCryptField + ": " + info[Constants.PlayStationLibCryptField]);
+                        break;
+                }
+                output.Add(Constants.PVDField + ":"); output.Add("");
+                output.AddRange(info[Constants.PVDField].Split('\n')); output.Add("");
+                switch (sys)
+                {
+                    case KnownSystem.AppleMacintosh:
+                    case KnownSystem.IBMPCCompatible:
+                        output.Add(Constants.CopyProtectionField + ": " + info[Constants.CopyProtectionField]); output.Add("");
+                        break;
+                }
+                // TODO: Add SecuROM data here for relevant things
+                switch (type)
+                {
+                    case DiscType.CD:
+                    case DiscType.GDROM:
+                        output.Add(Constants.CuesheetField + ":"); output.Add("");
+                        output.AddRange(info[Constants.CuesheetField].Split('\n')); output.Add("");
+                        output.Add(Constants.WriteOffsetField + ": " + info[Constants.WriteOffsetField]); output.Add("");
+                        break;
+                }
+                output.Add(Constants.DATField + ":"); output.Add("");
+                output.AddRange(info[Constants.DATField].Split('\n')); output.Add("");
+
+                return output;
+            }
+            catch
+            {
+                // We don't care what the error is
+                return null;
             }
         }
     }

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -744,20 +744,20 @@ namespace DICUI
             string combinedBase = Path.Combine(outputDirectory, outputFilename);
             Dictionary<string, string> mappings = new Dictionary<string, string>
             {
-                { Constants.TitleField, "(REQUIRED)" },
-                { Constants.DiscNumberField, "(OPTIONAL)" },
-                { Constants.DiscTitleField, "(OPTIONAL)" },
+                { Constants.TitleField, Constants.RequiredValue },
+                { Constants.DiscNumberField, Constants.OptionalValue },
+                { Constants.DiscTitleField, Constants.OptionalValue },
                 { Constants.CategoryField, "Games" },
                 { Constants.RegionField, "World (CHANGE THIS)" },
                 { Constants.LanguagesField, "Klingon (CHANGE THIS)" },
-                { Constants.DiscSerialField, "(OPTIONAL)" },
-                { Constants.MouldSIDField, "" },
-                { Constants.AdditionalMouldField, "" },
-                { Constants.BarcodeField, "" },
-                { Constants.ISBNField, "" },
-                { Constants.CommentsField, "(OPTIONAL)" },
-                { Constants.ContentsField, "(OPTIONAL)" },
-                { Constants.VersionField, "" },
+                { Constants.DiscSerialField, Constants.RequiredIfExistsValue },
+                { Constants.MouldSIDField, Constants.RequiredIfExistsValue },
+                { Constants.AdditionalMouldField, Constants.RequiredIfExistsValue },
+                { Constants.BarcodeField, Constants.OptionalValue},
+                { Constants.ISBNField, Constants.OptionalValue },
+                { Constants.CommentsField, Constants.OptionalValue },
+                { Constants.ContentsField, Constants.OptionalValue },
+                { Constants.VersionField, Constants.RequiredIfExistsValue },
                 { Constants.EditionField, "Original (VERIFY THIS)" },
                 { Constants.PVDField, GetPVD(combinedBase + "_mainInfo.txt") },
                 { Constants.DATField, GetDatfile(combinedBase + ".dat") },
@@ -768,9 +768,9 @@ namespace DICUI
             {
                 case DiscType.CD: // TODO: Add SecuROM data, but only if found
                 case DiscType.GDROM: // TODO: Verify GD-ROM outputs this
-                    mappings[Constants.MasteringRingField] = "";
-                    mappings[Constants.MasteringSIDField] = "";
-                    mappings[Constants.ToolstampField] = "";
+                    mappings[Constants.MasteringRingField] = Constants.RequiredIfExistsValue;
+                    mappings[Constants.MasteringSIDField] = Constants.RequiredIfExistsValue;
+                    mappings[Constants.ToolstampField] = Constants.RequiredIfExistsValue;
                     mappings[Constants.ErrorCountField] = GetErrorCount(combinedBase + ".img_EdcEcc.txt",
                         combinedBase + "_c2Error.txt",
                         combinedBase + "_mainError.txt").ToString();
@@ -782,20 +782,20 @@ namespace DICUI
                     {
                         case KnownSystem.AppleMacintosh:
                         case KnownSystem.IBMPCCompatible:
-                            mappings[Constants.CopyProtectionField] = "(REQUIRED, IF EXISTS)";
+                            mappings[Constants.CopyProtectionField] = Constants.RequiredIfExistsValue;
                             break;
                         case KnownSystem.SegaSaturn:
-                            mappings[Constants.SaturnHeaderField] = ""; // GetSaturnHeader(GetFirstTrack(outputDirectory, outputFilename));
-                            mappings[Constants.SaturnBuildDateField] = ""; //GetSaturnBuildDate(GetFirstTrack(outputDirectory, outputFilename));
+                            mappings[Constants.SaturnHeaderField] = Constants.RequiredValue; // GetSaturnHeader(GetFirstTrack(outputDirectory, outputFilename));
+                            mappings[Constants.SaturnBuildDateField] = Constants.RequiredValue; //GetSaturnBuildDate(GetFirstTrack(outputDirectory, outputFilename));
                             break;
                         case KnownSystem.SonyPlayStation:
-                            mappings[Constants.PlaystationEXEDateField] = ""; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
-                            mappings[Constants.PlayStationEDCField] = "Yes/No";
-                            mappings[Constants.PlayStationAntiModchipField] = "Yes/No";
-                            mappings[Constants.PlayStationLibCryptField] = "Yes/No";
+                            mappings[Constants.PlaystationEXEDateField] = Constants.RequiredValue; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
+                            mappings[Constants.PlayStationEDCField] = Constants.YesNoValue;
+                            mappings[Constants.PlayStationAntiModchipField] = Constants.YesNoValue;
+                            mappings[Constants.PlayStationLibCryptField] = Constants.YesNoValue;
                             break;
                         case KnownSystem.SonyPlayStation2:
-                            mappings[Constants.PlaystationEXEDateField] = ""; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
+                            mappings[Constants.PlaystationEXEDateField] = Constants.RequiredValue; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
                             break;
                     }
 
@@ -803,31 +803,31 @@ namespace DICUI
                 case DiscType.DVD5:
                 case DiscType.HDDVD:
                 case DiscType.BD25:
-                    mappings[Constants.MasteringRingField] = "";
-                    mappings[Constants.MasteringSIDField] = "";
-                    mappings[Constants.ToolstampField] = "";
+                    mappings[Constants.MasteringRingField] = Constants.RequiredIfExistsValue;
+                    mappings[Constants.MasteringSIDField] = Constants.RequiredIfExistsValue;
+                    mappings[Constants.ToolstampField] = Constants.RequiredIfExistsValue;
 
                     // System-specific options
                     switch (sys)
                     {
                         case KnownSystem.AppleMacintosh:
                         case KnownSystem.IBMPCCompatible:
-                            mappings[Constants.CopyProtectionField] = "(REQUIRED, IF EXISTS)";
+                            mappings[Constants.CopyProtectionField] = Constants.RequiredIfExistsValue;
                             break;
                         case KnownSystem.SonyPlayStation2:
-                            mappings[Constants.PlaystationEXEDateField] = ""; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
+                            mappings[Constants.PlaystationEXEDateField] = Constants.RequiredValue; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
                             break;
                     }
 
                     break;
                 case DiscType.DVD9:
                 case DiscType.BD50:
-                    mappings["Outer " + Constants.MasteringRingField] = "";
-                    mappings["Inner " + Constants.MasteringRingField] = "";
-                    mappings["Outer " + Constants.MasteringSIDField] = "";
-                    mappings["Inner " + Constants.MasteringSIDField] = "";
-                    mappings["Outer " + Constants.ToolstampField] = "";
-                    mappings["Inner " + Constants.ToolstampField] = "";
+                    mappings["Outer " + Constants.MasteringRingField] = Constants.RequiredIfExistsValue;
+                    mappings["Inner " + Constants.MasteringRingField] = Constants.RequiredIfExistsValue;
+                    mappings["Outer " + Constants.MasteringSIDField] = Constants.RequiredIfExistsValue;
+                    mappings["Inner " + Constants.MasteringSIDField] = Constants.RequiredIfExistsValue;
+                    mappings["Outer " + Constants.ToolstampField] = Constants.RequiredIfExistsValue;
+                    mappings["Inner " + Constants.ToolstampField] = Constants.RequiredIfExistsValue;
                     mappings[Constants.LayerbreakField] = GetLayerbreak(combinedBase + "_disc.txt");
 
                     // System-specific options
@@ -835,10 +835,10 @@ namespace DICUI
                     {
                         case KnownSystem.AppleMacintosh:
                         case KnownSystem.IBMPCCompatible:
-                            mappings[Constants.CopyProtectionField] = "(REQUIRED, IF EXISTS)";
+                            mappings[Constants.CopyProtectionField] = Constants.RequiredIfExistsValue;
                             break;
                         case KnownSystem.SonyPlayStation2:
-                            mappings[Constants.PlaystationEXEDateField] = ""; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
+                            mappings[Constants.PlaystationEXEDateField] = Constants.RequiredValue; // GetPlaysStationEXEDate(combinedBase + "_mainInfo.txt");
                             break;
                     }
 
@@ -1158,8 +1158,8 @@ namespace DICUI
                         output.Add("Inner " + Constants.ToolstampField + ": " + info["Inner " + Constants.ToolstampField]);
                         break;
                 }
-                output.Add(info[Constants.BarcodeField + ": " + Constants.BarcodeField]);
-                output.Add(info[Constants.ISBNField + ": " + Constants.ISBNField]);
+                output.Add(Constants.BarcodeField + ": " + info[Constants.BarcodeField]);
+                output.Add(Constants.ISBNField + ": " + info[Constants.ISBNField]);
                 switch (type)
                 {
                     case DiscType.CD:
@@ -1223,14 +1223,20 @@ namespace DICUI
         /// <returns>True on success, false on error</returns>
         public static bool WriteOutputData(string outputDirectory, string outputFilename, List<string> lines)
         {
-            // First, sanitized the output filename to strip off any potential extension
+            // Check to see if the inputs are valid
+            if (lines == null)
+            {
+                return false;
+            }
+
+            // Then, sanitized the output filename to strip off any potential extension
             outputFilename = Path.GetFileNameWithoutExtension(outputFilename);
 
             // Now write out to a generic file
             string combinedBase = Path.Combine(outputDirectory, outputFilename);
             try
             {
-                using (StreamWriter sw = new StreamWriter(File.OpenWrite(combinedBase + ".txt")))
+                using (StreamWriter sw = new StreamWriter(File.Open(combinedBase + ".txt", FileMode.Create, FileAccess.Write)))
                 {
                     foreach (string line in lines)
                     {


### PR DESCRIPTION
First round of outputting all required disc information to file for easy submission.

Currently fully supports:
- Apple Macintosh (CD/DVD)
- IBM PC Compatibles (CD/DVD)
- Sega Saturn (CD, some values are not automatically generated)
- Sony PlayStation (CD, some values are not automatically generated)
- Sony PlayStation 2 (CD/DVD, some values are not automatically generated)
- Generic CD, DVD, BD (only default information, no system-specific ones)

Current known issues:
- PSX libcrypt, EDC, and Anti-modchip are not filled in automatically
- PSX/PS2 EXE dates are not filled in automatically
- Saturn header and build date are not filled in automatically
- Not all system-specific values are supported

Addresses #9, #23 