### PR TITLE
Add Custom Parameter Support

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -30,28 +30,30 @@
             <Grid.RowDefinitions>
                 <RowDefinition/>
                 <RowDefinition/>
-
+                <RowDefinition/>
                 <RowDefinition/>
                 <RowDefinition/>
                 <RowDefinition/>
             </Grid.RowDefinitions>
 
             <Label Grid.Row="0" Grid.Column="0" VerticalAlignment="Center">Disc Type</Label>
-            <Label Grid.Row="1" Grid.Column="0" VerticalAlignment="Center">Output Filename</Label>
-            <Label Grid.Row="2" Grid.Column="0" VerticalAlignment="Center">Output Directory</Label>
-            <Label Grid.Row="3" Grid.Column="0" VerticalAlignment="Center">Drive Letter</Label>
-            <Label Grid.Row="4" Grid.Column="0" VerticalAlignment="Center">Drive Speed</Label>
-
             <ComboBox x:Name="cmb_DiscType" Grid.Row="0" Grid.Column="1" Height="22" SelectionChanged="cmb_DiscType_SelectionChanged" />
 
+            <Label Grid.Row="1" Grid.Column="0" VerticalAlignment="Center">Output Filename</Label>
             <TextBox x:Name="txt_OutputFilename" Grid.Row="1" Grid.Column="1" Height="22"></TextBox>
 
+            <Label Grid.Row="2" Grid.Column="0" VerticalAlignment="Center">Output Directory</Label>
             <TextBox x:Name="txt_OutputDirectory" Grid.Row="2" Grid.Column="1" Height="22" Width="345" HorizontalAlignment="left" Text="ISO" />
             <Button x:Name="btn_OutputDirectoryBrowse" Grid.Row="2" Grid.Column="1" Height="22" Width="50" HorizontalAlignment="Right" Content="Browse" Click="btn_OutputDirectoryBrowse_Click"/>
 
+            <Label Grid.Row="3" Grid.Column="0" VerticalAlignment="Center">Drive Letter</Label>
             <ComboBox x:Name="cmb_DriveLetter" Grid.Row="3" Grid.Column="1" Height="22" Width="397" HorizontalAlignment="left" SelectionChanged="cmb_DriveLetter_SelectionChanged"/>
 
-            <ComboBox x:Name="cmb_DriveSpeed" Grid.Row="4" Grid.Column="1" Height="22" Width="60" HorizontalAlignment="left"/>
+            <Label Grid.Row="4" Grid.Column="0" VerticalAlignment="Center">Drive Speed</Label>
+            <ComboBox x:Name="cmb_DriveSpeed" Grid.Row="4" Grid.Column="1" Height="22" Width="60" HorizontalAlignment="left" SelectionChanged="cmb_DriveSpeed_SelectionChanged"/>
+
+            <Label Grid.Row="5" Grid.Column="0" VerticalAlignment="Center">Custom Parameters</Label>
+            <TextBox x:Name="txt_CustomParameters" Grid.Row="5" Grid.Column="1" Height="22" Width="397" HorizontalAlignment="left" IsEnabled="False" />
         </Grid>
 
         <Grid Grid.Row="1" Grid.Column="0" Margin="15,19.6,15.2,9.8" Grid.ColumnSpan="2">
@@ -76,9 +78,6 @@
             </Grid.RowDefinitions>
 
             <Label x:Name="lbl_Status" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Center" Content="Waiting for CD or DVD..." />
-
         </Grid>
-
     </Grid>
-    
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -77,6 +77,8 @@ namespace DICUI
             cmb_DiscType.DisplayMemberPath = "Item1";
             cmb_DiscType.SelectedIndex = 0;
             cmb_DiscType_SelectionChanged(null, null);
+
+            btn_Start.IsEnabled = false;
         }
 
         /// <summary>
@@ -181,7 +183,7 @@ namespace DICUI
                     if (!File.Exists(sgRawPath))
                     {
                         lbl_Status.Content = "Error! Could not find sg-raw!";
-                        return;
+                        break;
                     }
 
                     Process sgraw = new Process()
@@ -199,7 +201,7 @@ namespace DICUI
                     if (!File.Exists(psxtPath))
                     {
                         lbl_Status.Content = "Error! Could not find psxt001z!";
-                        return;
+                        break;
                     }
 
                     // Invoke the program with all 3 configurations
@@ -273,17 +275,21 @@ namespace DICUI
             {
                 case DiscType.NONE:
                     lbl_Status.Content = "Please select a valid disc type";
+                    btn_Start.IsEnabled = false;
                     break;
                 case DiscType.GameCubeGameDisc:
                 case DiscType.GDROM:
                     lbl_Status.Content = string.Format("{0} discs are partially supported by DIC", Utilities.DiscTypeToString(tuple.Item3));
+                    btn_Start.IsEnabled = true;
                     break;
                 case DiscType.HDDVD:
                 case DiscType.UMD:
                     lbl_Status.Content = string.Format("{0} discs are not currently supported by DIC", Utilities.DiscTypeToString(tuple.Item3));
+                    btn_Start.IsEnabled = true;
                     break;
                 default:
                     lbl_Status.Content = string.Format("{0} ready to dump", Utilities.DiscTypeToString(tuple.Item3));
+                    btn_Start.IsEnabled = true;
                     break;
             }
 

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -603,6 +603,9 @@ namespace DICUI
                 }
             }
 
+            // Add final mapping for "Custom"
+            mapping.Add(new Tuple<string, KnownSystem?, DiscType?>("Custom Input", KnownSystem.NONE, DiscType.NONE));
+
             return mapping;
         }
 


### PR DESCRIPTION
Addresses #14.

This change makes it so that the current commandline params are displayed in a disabled text box but when the custom option is selected, the other parts get disabled and you have full control over the commandline. This can allow any customization that users would like. It also simplifies the code that gets called when the DiscImageCreator instance gets run.

The changes to the xaml are incidental, they're just reordering (sans the addition of the new grid row for the custom parameters).