### PR TITLE
Add verification for overwrite

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -162,6 +162,17 @@ namespace DICUI
                 return;
             }
 
+            // If a complete dump already exists
+            if (Utilities.FoundAllFiles(outputDirectory, outputFilename, selected.Item3))
+            {
+                MessageBoxResult result = MessageBox.Show("A complete dump already exists! Are you sure you want to overwrite?", "Overwrite?", MessageBoxButton.YesNo, MessageBoxImage.Exclamation);
+                if (result == MessageBoxResult.No || result == MessageBoxResult.Cancel || result == MessageBoxResult.None)
+                {
+                    lbl_Status.Content = "Dumping aborted!";
+                    return;
+                }
+            }
+
             lbl_Status.Content = "Beginning dumping process";
             await Task.Run(
                 () =>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -149,9 +149,11 @@ namespace DICUI
             var selected = cmb_DiscType.SelectedValue as Tuple<string, KnownSystem?, DiscType?>;
 
             // Validate that everything is good
+            // TODO: Add full validation of the parameters
             if (string.IsNullOrWhiteSpace(txt_CustomParameters.Text))
             {
                 lbl_Status.Content = "Error! Current configuration is not supported!";
+                btn_Start.IsEnabled = true;
                 return;
             }
 
@@ -159,6 +161,7 @@ namespace DICUI
             if (!File.Exists(dicPath))
             {
                 lbl_Status.Content = "Error! Could not find DiscImageCreator!";
+                btn_Start.IsEnabled = true;
                 return;
             }
 
@@ -169,6 +172,7 @@ namespace DICUI
                 if (result == MessageBoxResult.No || result == MessageBoxResult.Cancel || result == MessageBoxResult.None)
                 {
                     lbl_Status.Content = "Dumping aborted!";
+                    btn_Start.IsEnabled = true;
                     return;
                 }
             }
@@ -254,6 +258,7 @@ namespace DICUI
             if (!Utilities.FoundAllFiles(outputDirectory, outputFilename, selected.Item3))
             {
                 lbl_Status.Content = "Error! Please check output directory as dump may be incomplete!";
+                btn_Start.IsEnabled = true;
                 return;
             }
 


### PR DESCRIPTION
Add verification dialog in case the user is overwriting a complete existing dump. This is ONLY for a complete existing dump, so users who ran into an error won't be pestered every time.

Addresses #30 