### PR TITLE
Formats and Types

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -95,8 +95,8 @@
         public const string DATField = "DAT";
         public const string ErrorCountField = "Error Count";
         public const string CuesheetField = "Cuesheet";
-        public const string SubIntentionField = "SubIntention (SecuROM)";
-        public const string WriteOffsetField = "WriteOffset";
+        public const string SubIntentionField = "SubIntention Data (SecuROM)";
+        public const string WriteOffsetField = "Write Offset";
         public const string LayerbreakField = "Layerbreak";
         public const string PlaystationEXEDateField = "EXE Date";
         public const string PlayStationEDCField = "EDC"; // TODO: Not automatic yet

--- a/Enumerations.cs
+++ b/Enumerations.cs
@@ -7,12 +7,10 @@
     {
         NONE = 0,
         CD,
-        DVD5,
-        DVD9,
+        DVD,
         GDROM,
         HDDVD,
-        BD25,
-        BD50,
+        BluRay,
 
         // Special Formats
         GameCubeGameDisc,
@@ -142,6 +140,7 @@
         BDVideo,
         DVDVideo,
         EnhancedCD,
+        HDDVDVideo,
         PalmOS,
         PhilipsCDiDigitalVideo,
         PhotoCD,

--- a/Enumerations.cs
+++ b/Enumerations.cs
@@ -5,21 +5,26 @@
     /// </summary>
     public enum DiscType
     {
+        // Generic Optical Formats
         NONE = 0,
         CD,
         DVD,
         GDROM,
         HDDVD,
         BluRay,
+        LaserDisc,
 
-        // Special Formats
+        // Special Optical Formats
+        CED,
         GameCubeGameDisc,
         WiiOpticalDisc,
         WiiUOpticalDisc,
         UMD,
         
-        // Keeping this separate since it's currently unsupported in the UI
-        Floppy = 99,
+        // Non-Optical Formats
+        Floppy,
+        Cassette,
+        Cartridge,
     }
 
     /// <summary>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -137,20 +137,20 @@ namespace DICUI
             EnsureDiscInformation();
         }
 
-		#endregion
+        #endregion
 
-		#region Helpers
+        #region Helpers
 
-		/// <summary>
-		/// Populate disc type according to system type
-		/// </summary>
-		private void PopulateDiscTypeAccordingToChosenSystem()
+        /// <summary>
+        /// Populate disc type according to system type
+        /// </summary>
+        private void PopulateDiscTypeAccordingToChosenSystem()
         {
             var currentSystem = cmb_SystemType.SelectedItem as Tuple<string, KnownSystem?>;
 
             if (currentSystem != null)
             {
-				_discTypes = Utilities.Validation.GetValidDiscTypes(currentSystem.Item2);
+                _discTypes = Utilities.Validation.GetValidDiscTypes(currentSystem.Item2);
                 cmb_DiscType.ItemsSource = _discTypes;
                 cmb_DiscType.DisplayMemberPath = "Item1";
 
@@ -234,18 +234,19 @@ namespace DICUI
         {
             btn_StartStop.Content = UIElements.StopDumping;
 
-            // Get the currently selected options
+            // Populate all tuples
             var driveLetterTuple = cmb_DriveLetter.SelectedItem as Tuple<char, string, bool>;
+            var systemTypeTuple = cmb_SystemType.SelectedValue as Tuple<string, KnownSystem?>;
+            var discTypeTuple = cmb_DiscType.SelectedValue as Tuple<string, DiscType?>;
+
+            // Get the currently selected options
             char driveLetter = driveLetterTuple.Item1;
             bool isFloppy = driveLetterTuple.Item3;
-
             string outputDirectory = txt_OutputDirectory.Text;
             string outputFilename = txt_OutputFilename.Text;
-
-            var selected = cmb_SystemType.SelectedValue as Tuple<string, KnownSystem?, DiscType?>;
-            string systemName = selected.Item1;
-            KnownSystem? system = selected.Item2;
-            DiscType? type = selected.Item3;
+            string systemName = systemTypeTuple.Item1;
+            KnownSystem? system = systemTypeTuple.Item2;
+            DiscType? type = discTypeTuple.Item2;
 
             string customParameters = txt_Parameters.Text;
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -517,9 +517,13 @@ namespace DICUI
                         btn_StartStop.IsEnabled = (_drives.Count > 0 ? true : false);
                         break;
                     case DiscType.HDDVD:
+                    case DiscType.LaserDisc:
+                    case DiscType.CED:
                     case DiscType.UMD:
                     case DiscType.WiiOpticalDisc:
                     case DiscType.WiiUOpticalDisc:
+                    case DiscType.Cartridge:
+                    case DiscType.Cassette:
                         lbl_Status.Content = string.Format("{0} discs are not currently supported by DIC", discTypeTuple.Item1);
                         btn_StartStop.IsEnabled = false;
                         break;

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -145,29 +145,25 @@ namespace DICUI
         /// Populate disc type according to system type
         private void PopulateDiscTypeAccordingToChosenSystem()
         {
-          cmb_DiscType.SelectedIndex = -1;
+            var currentSystem = cmb_SystemType.SelectedItem as Tuple<string, KnownSystem?>;
 
-          var currentSystem = cmb_SystemType.SelectedItem as Tuple<string, KnownSystem?>;
+            if (currentSystem != null)
+            {
+                List<Tuple<string, DiscType?>> allowedDiscTypesForSystem = Utilities.Validation.GetValidDiscTypes(currentSystem.Item2)
+                  .ConvertAll(d => Tuple.Create(Converters.DiscTypeToString(d), d));
 
-          if (currentSystem != null)
-          {
-            List<Tuple<string, DiscType?>> allowedDiscTypesForSystem = Utilities.Validation.GetValidDiscTypes(currentSystem.Item2)
-              .ConvertAll(d => Tuple.Create(Utilities.Converters.DiscTypeToString(d), d));
+                cmb_DiscType.ItemsSource = allowedDiscTypesForSystem;
+                cmb_DiscType.DisplayMemberPath = "Item1";
 
-            cmb_DiscType.ItemsSource = allowedDiscTypesForSystem;
-            cmb_DiscType.DisplayMemberPath = "Item1";
-
-            cmb_DiscType.IsEnabled = allowedDiscTypesForSystem.Count > 1;
-
-            if (!cmb_DiscType.IsEnabled)
-              cmb_DiscType.SelectedIndex = 0;
-          }
-          else
-          {
-            cmb_DiscType.IsEnabled = false;
-            cmb_DiscType.ItemsSource = null;
-            cmb_DiscType.SelectedIndex = 0;
-          }
+                cmb_DiscType.IsEnabled = allowedDiscTypesForSystem.Count > 1;
+                cmb_DiscType.SelectedIndex = 0;
+            }
+            else
+            {
+                cmb_DiscType.IsEnabled = false;
+                cmb_DiscType.ItemsSource = null;
+                cmb_DiscType.SelectedIndex = -1;
+            }
         }
         /// </summary>
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -523,8 +523,7 @@ namespace DICUI
                         lbl_Status.Content = string.Format("{0} discs are not currently supported by DIC", discTypeTuple.Item1);
                         btn_StartStop.IsEnabled = false;
                         break;
-                    case DiscType.DVD5:
-                    case DiscType.DVD9:
+                    case DiscType.DVD:
                         if (selectedSystem == KnownSystem.MicrosoftXBOX360XDG3)
                         {
                             lbl_Status.Content = string.Format("{0} discs are not currently supported by DIC", discTypeTuple.Item1);
@@ -547,8 +546,7 @@ namespace DICUI
             switch (selectedDiscType)
             {
                 case DiscType.Floppy:
-                case DiscType.BD25:
-                case DiscType.BD50:
+                case DiscType.BluRay:
                     cmb_DriveSpeed.IsEnabled = false;
                     break;
                 default:
@@ -600,8 +598,7 @@ namespace DICUI
                         + " " + driveletter.Item1
                         + " \"" + Path.Combine(txt_OutputDirectory.Text, txt_OutputFilename.Text) + "\" "
                         + (selectedDiscType != DiscType.Floppy
-                            && selectedDiscType != DiscType.BD25
-                            && selectedDiscType != DiscType.BD50
+                            && selectedDiscType != DiscType.BluRay
                             && selectedSystem != KnownSystem.MicrosoftXBOX
                             && selectedSystem != KnownSystem.MicrosoftXBOX360XDG2
                             && selectedSystem != KnownSystem.MicrosoftXBOX360XDG3

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -137,25 +137,24 @@ namespace DICUI
             EnsureDiscInformation();
         }
 
-        #endregion
+		#endregion
 
-        #region Helpers
+		#region Helpers
 
-        /// <summary>
-        /// Populate disc type according to system type
-        private void PopulateDiscTypeAccordingToChosenSystem()
+		/// <summary>
+		/// Populate disc type according to system type
+		/// </summary>
+		private void PopulateDiscTypeAccordingToChosenSystem()
         {
             var currentSystem = cmb_SystemType.SelectedItem as Tuple<string, KnownSystem?>;
 
             if (currentSystem != null)
             {
-                List<Tuple<string, DiscType?>> allowedDiscTypesForSystem = Utilities.Validation.GetValidDiscTypes(currentSystem.Item2)
-                  .ConvertAll(d => Tuple.Create(Converters.DiscTypeToString(d), d));
-
-                cmb_DiscType.ItemsSource = allowedDiscTypesForSystem;
+				_discTypes = Utilities.Validation.GetValidDiscTypes(currentSystem.Item2);
+                cmb_DiscType.ItemsSource = _discTypes;
                 cmb_DiscType.DisplayMemberPath = "Item1";
 
-                cmb_DiscType.IsEnabled = allowedDiscTypesForSystem.Count > 1;
+                cmb_DiscType.IsEnabled = _discTypes.Count > 1;
                 cmb_DiscType.SelectedIndex = 0;
             }
             else
@@ -165,7 +164,6 @@ namespace DICUI
                 cmb_DiscType.SelectedIndex = -1;
             }
         }
-        /// </summary>
 
         /// <summary>
         /// Get a complete list of supported systems and fill the combo box
@@ -173,8 +171,6 @@ namespace DICUI
         private void PopulateSystems()
         {
             _systems = Utilities.Validation.CreateListOfSystems();
-            _discTypes = Utilities.Validation.CreateListOfDiscTypesForKnownSystems(_systems.ConvertAll(s => s.Item2));
-
             cmb_SystemType.ItemsSource = _systems;
             cmb_SystemType.DisplayMemberPath = "Item1";
             cmb_SystemType.SelectedIndex = 0;

--- a/Utilities/Converters.cs
+++ b/Utilities/Converters.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace DICUI.Utilities
 {
@@ -197,8 +199,8 @@ namespace DICUI.Utilities
         public static List<string> KnownSystemAndDiscTypeToParameters(KnownSystem? sys, DiscType? type)
         {
             // First check to see if the combination of system and disctype is valid
-            List<DiscType?> validTypes = Validation.GetValidDiscTypes(sys);
-            if (!validTypes.Contains(type))
+            List<Tuple<string, DiscType?>> validTypes = Validation.GetValidDiscTypes(sys);
+            if (!validTypes.Select(i => i.Item2).Contains(type))
             {
                 return null;
             }

--- a/Utilities/Converters.cs
+++ b/Utilities/Converters.cs
@@ -20,11 +20,10 @@ namespace DICUI.Utilities
                 case DICCommands.Swap:
                     return DiscType.GDROM;
                 case DICCommands.DigitalVideoDisc:
-                    return DiscType.DVD9;
-                case DICCommands.BluRay:
-                    return DiscType.BD50;
                 case DICCommands.XBOX:
-                    return DiscType.DVD5;
+                    return DiscType.DVD;
+                case DICCommands.BluRay:
+                    return DiscType.BluRay;
 
                 // Non-optical
                 case DICCommands.Floppy:
@@ -71,11 +70,9 @@ namespace DICUI.Utilities
                 case DiscType.CD:
                 case DiscType.GDROM:
                     return ".bin";
-                case DiscType.DVD5:
-                case DiscType.DVD9:
+                case DiscType.DVD:
                 case DiscType.HDDVD:
-                case DiscType.BD25:
-                case DiscType.BD50:
+                case DiscType.BluRay:
                 case DiscType.WiiOpticalDisc:
                 case DiscType.UMD:
                     return ".iso";
@@ -102,18 +99,14 @@ namespace DICUI.Utilities
             {
                 case DiscType.CD:
                     return "CD-ROM";
-                case DiscType.DVD5:
-                    return "DVD-5 [Single-Layer]";
-                case DiscType.DVD9:
-                    return "DVD-9 [Dual-Layer]";
+                case DiscType.DVD:
+                    return "DVD";
                 case DiscType.GDROM:
                     return "GD-ROM";
                 case DiscType.HDDVD:
                     return "HD-DVD";
-                case DiscType.BD25:
-                    return "BluRay-25 [Single-Layer]";
-                case DiscType.BD50:
-                    return "BluRay-50 [Dual-Layer]";
+                case DiscType.BluRay:
+                    return "BluRay";
 
                 case DiscType.GameCubeGameDisc:
                     return "GameCube Game";
@@ -148,15 +141,7 @@ namespace DICUI.Utilities
                         return DICCommands.XBOX;
                     }
                     return DICCommands.CompactDisc;
-                case DiscType.DVD5:
-                    if (sys == KnownSystem.MicrosoftXBOX
-                        || sys == KnownSystem.MicrosoftXBOX360XDG2
-                        || sys == KnownSystem.MicrosoftXBOX360XDG3)
-                    {
-                        return DICCommands.XBOX;
-                    }
-                    return DICCommands.DigitalVideoDisc;
-                case DiscType.DVD9:
+                case DiscType.DVD:
                     if (sys == KnownSystem.MicrosoftXBOX
                         || sys == KnownSystem.MicrosoftXBOX360XDG2
                         || sys == KnownSystem.MicrosoftXBOX360XDG3)
@@ -168,8 +153,7 @@ namespace DICUI.Utilities
                     return DICCommands.GDROM;
                 case DiscType.HDDVD:
                     return null;
-                case DiscType.BD25:
-                case DiscType.BD50:
+                case DiscType.BluRay:
                     return DICCommands.BluRay;
 
                 // Special Formats
@@ -229,10 +213,7 @@ namespace DICUI.Utilities
                             break;
                     }
                     break;
-                case DiscType.DVD5:
-                    // Currently no defaults set
-                    break;
-                case DiscType.DVD9:
+                case DiscType.DVD:
                     // Currently no defaults set
                     break;
                 case DiscType.GDROM:
@@ -240,10 +221,7 @@ namespace DICUI.Utilities
                     break;
                 case DiscType.HDDVD:
                     break;
-                case DiscType.BD25:
-                    // Currently no defaults set
-                    break;
-                case DiscType.BD50:
+                case DiscType.BluRay:
                     // Currently no defaults set
                     break;
 
@@ -481,6 +459,8 @@ namespace DICUI.Utilities
                     return "DVD-Video";
                 case KnownSystem.EnhancedCD:
                     return "Enhanced CD";
+                case KnownSystem.HDDVDVideo:
+                    return "HD-DVD-Video";
                 case KnownSystem.PalmOS:
                     return "PalmOS";
                 case KnownSystem.PhilipsCDiDigitalVideo:

--- a/Utilities/Converters.cs
+++ b/Utilities/Converters.cs
@@ -69,6 +69,7 @@ namespace DICUI.Utilities
             {
                 case DiscType.CD:
                 case DiscType.GDROM:
+                case DiscType.Cartridge:
                     return ".bin";
                 case DiscType.DVD:
                 case DiscType.HDDVD:
@@ -76,13 +77,17 @@ namespace DICUI.Utilities
                 case DiscType.WiiOpticalDisc:
                 case DiscType.UMD:
                     return ".iso";
+                case DiscType.LaserDisc:
                 case DiscType.GameCubeGameDisc:
                     return ".raw";
                 case DiscType.WiiUOpticalDisc:
                     return ".wud";
                 case DiscType.Floppy:
                     return ".img";
+                case DiscType.Cassette:
+                    return ".wav";
                 case DiscType.NONE:
+                case DiscType.CED:
                 default:
                     return null;
             }
@@ -107,7 +112,11 @@ namespace DICUI.Utilities
                     return "HD-DVD";
                 case DiscType.BluRay:
                     return "BluRay";
+                case DiscType.LaserDisc:
+                    return "LaserDisc";
 
+                case DiscType.CED:
+                    return "CED";
                 case DiscType.GameCubeGameDisc:
                     return "GameCube Game";
                 case DiscType.WiiOpticalDisc:
@@ -117,6 +126,10 @@ namespace DICUI.Utilities
                 case DiscType.UMD:
                     return "UMD";
 
+                case DiscType.Cartridge:
+                    return "Cartridge";
+                case DiscType.Cassette:
+                    return "Cassette Tape";
                 case DiscType.Floppy:
                     return "Floppy Disk";
 

--- a/Utilities/DumpInformation.cs
+++ b/Utilities/DumpInformation.cs
@@ -85,11 +85,9 @@ namespace DICUI.Utilities
                         && File.Exists(combinedBase + "_subIntention.txt")
                         && File.Exists(combinedBase + "_subReadable.txt")
                         && File.Exists(combinedBase + "_volDesc.txt");
-                case DiscType.DVD5:
-                case DiscType.DVD9:
+                case DiscType.DVD:
                 case DiscType.HDDVD:
-                case DiscType.BD25:
-                case DiscType.BD50:
+                case DiscType.BluRay:
                 case DiscType.GameCubeGameDisc:
                 case DiscType.WiiOpticalDisc:
                 case DiscType.WiiUOpticalDisc:
@@ -206,51 +204,35 @@ namespace DICUI.Utilities
                     }
 
                     break;
-                case DiscType.DVD5:
+                case DiscType.DVD:
                 case DiscType.HDDVD:
-                case DiscType.BD25:
-                    mappings[Template.MasteringRingField] = Template.RequiredIfExistsValue;
-                    mappings[Template.MasteringSIDField] = Template.RequiredIfExistsValue;
-                    mappings[Template.MouldSIDField] = Template.RequiredIfExistsValue;
-                    mappings[Template.AdditionalMouldField] = Template.RequiredIfExistsValue;
-                    mappings[Template.ToolstampField] = Template.RequiredIfExistsValue;
-                    mappings[Template.PVDField] = GetPVD(combinedBase + "_mainInfo.txt");
-
-                    // System-specific options
-                    switch (sys)
+                case DiscType.BluRay:
+                    string layerbreak = GetLayerbreak(combinedBase + "_disc.txt");
+                    
+                    // If we have a single-layer disc
+                    if (layerbreak == null)
                     {
-                        case KnownSystem.AppleMacintosh:
-                        case KnownSystem.IBMPCCompatible:
-                            mappings[Template.ISBNField] = Template.OptionalValue;
-                            mappings[Template.CopyProtectionField] = Template.RequiredIfExistsValue;
-                            if (File.Exists(combinedBase + "_subIntention.txt"))
-                            {
-                                FileInfo fi = new FileInfo(combinedBase + "_subIntention.txt");
-                                if (fi.Length > 0)
-                                {
-                                    mappings[Template.SubIntentionField] = GetFullFile(combinedBase + "_subIntention.txt");
-                                }
-                            }
-                            break;
-                        case KnownSystem.SonyPlayStation2:
-                            mappings[Template.PlaystationEXEDateField] = GetPlayStationEXEDate(driveLetter);
-                            mappings[Template.VersionField] = GetPlayStation2Version(driveLetter);
-                            break;
+                        mappings[Template.MasteringRingField] = Template.RequiredIfExistsValue;
+                        mappings[Template.MasteringSIDField] = Template.RequiredIfExistsValue;
+                        mappings[Template.MouldSIDField] = Template.RequiredIfExistsValue;
+                        mappings[Template.AdditionalMouldField] = Template.RequiredIfExistsValue;
+                        mappings[Template.ToolstampField] = Template.RequiredIfExistsValue;
+                        mappings[Template.PVDField] = GetPVD(combinedBase + "_mainInfo.txt");
                     }
-
-                    break;
-                case DiscType.DVD9:
-                case DiscType.BD50:
-                    mappings["Outer " + Template.MasteringRingField] = Template.RequiredIfExistsValue;
-                    mappings["Inner " + Template.MasteringRingField] = Template.RequiredIfExistsValue;
-                    mappings["Outer " + Template.MasteringSIDField] = Template.RequiredIfExistsValue;
-                    mappings["Inner " + Template.MasteringSIDField] = Template.RequiredIfExistsValue;
-                    mappings[Template.MouldSIDField] = Template.RequiredIfExistsValue;
-                    mappings[Template.AdditionalMouldField] = Template.RequiredIfExistsValue;
-                    mappings["Outer " + Template.ToolstampField] = Template.RequiredIfExistsValue;
-                    mappings["Inner " + Template.ToolstampField] = Template.RequiredIfExistsValue;
-                    mappings[Template.PVDField] = GetPVD(combinedBase + "_mainInfo.txt");
-                    mappings[Template.LayerbreakField] = GetLayerbreak(combinedBase + "_disc.txt");
+                    // If we have a dual-layer disc
+                    else
+                    {
+                        mappings["Outer " + Template.MasteringRingField] = Template.RequiredIfExistsValue;
+                        mappings["Inner " + Template.MasteringRingField] = Template.RequiredIfExistsValue;
+                        mappings["Outer " + Template.MasteringSIDField] = Template.RequiredIfExistsValue;
+                        mappings["Inner " + Template.MasteringSIDField] = Template.RequiredIfExistsValue;
+                        mappings[Template.MouldSIDField] = Template.RequiredIfExistsValue;
+                        mappings[Template.AdditionalMouldField] = Template.RequiredIfExistsValue;
+                        mappings["Outer " + Template.ToolstampField] = Template.RequiredIfExistsValue;
+                        mappings["Inner " + Template.ToolstampField] = Template.RequiredIfExistsValue;
+                        mappings[Template.PVDField] = GetPVD(combinedBase + "_mainInfo.txt");
+                        mappings[Template.LayerbreakField] = layerbreak;
+                    }
 
                     // System-specific options
                     switch (sys)
@@ -284,7 +266,6 @@ namespace DICUI.Utilities
                             mappings[Template.VersionField] = GetPlayStation2Version(driveLetter);
                             break;
                     }
-
                     break;
             }
 
@@ -808,25 +789,30 @@ namespace DICUI.Utilities
                 {
                     case DiscType.CD:
                     case DiscType.GDROM:
-                    case DiscType.DVD5:
+                    case DiscType.DVD:
                     case DiscType.HDDVD:
-                    case DiscType.BD25:
-                        output.Add("\t" + Template.MasteringRingField + ": " + info[Template.MasteringRingField]);
-                        output.Add("\t" + Template.MasteringSIDField + ": " + info[Template.MasteringSIDField]);
-                        output.Add("\t" + Template.MouldSIDField + ": " + info[Template.MouldSIDField]);
-                        output.Add("\t" + Template.AdditionalMouldField + ": " + info[Template.AdditionalMouldField]);
-                        output.Add("\t" + Template.ToolstampField + ": " + info[Template.ToolstampField]);
-                        break;
-                    case DiscType.DVD9:
-                    case DiscType.BD50:
-                        output.Add("\tOuter " + Template.MasteringRingField + ": " + info["Outer " + Template.MasteringRingField]);
-                        output.Add("\tInner " + Template.MasteringRingField + ": " + info["Inner " + Template.MasteringRingField]);
-                        output.Add("\tOuter " + Template.MasteringSIDField + ": " + info["Outer " + Template.MasteringSIDField]);
-                        output.Add("\tInner " + Template.MasteringSIDField + ": " + info["Inner " + Template.MasteringSIDField]);
-                        output.Add("\t" + Template.MouldSIDField + ": " + info[Template.MouldSIDField]);
-                        output.Add("\t" + Template.AdditionalMouldField + ": " + info[Template.AdditionalMouldField]);
-                        output.Add("\tOuter " + Template.ToolstampField + ": " + info["Outer " + Template.ToolstampField]);
-                        output.Add("\tInner " + Template.ToolstampField + ": " + info["Inner " + Template.ToolstampField]);
+                    case DiscType.BluRay:
+                        // If we have a dual-layer disc
+                        if (info.ContainsKey(Template.LayerbreakField))
+                        {
+                            output.Add("\tOuter " + Template.MasteringRingField + ": " + info["Outer " + Template.MasteringRingField]);
+                            output.Add("\tInner " + Template.MasteringRingField + ": " + info["Inner " + Template.MasteringRingField]);
+                            output.Add("\tOuter " + Template.MasteringSIDField + ": " + info["Outer " + Template.MasteringSIDField]);
+                            output.Add("\tInner " + Template.MasteringSIDField + ": " + info["Inner " + Template.MasteringSIDField]);
+                            output.Add("\t" + Template.MouldSIDField + ": " + info[Template.MouldSIDField]);
+                            output.Add("\t" + Template.AdditionalMouldField + ": " + info[Template.AdditionalMouldField]);
+                            output.Add("\tOuter " + Template.ToolstampField + ": " + info["Outer " + Template.ToolstampField]);
+                            output.Add("\tInner " + Template.ToolstampField + ": " + info["Inner " + Template.ToolstampField]);
+                        }
+                        // If we have a single-layer disc
+                        else
+                        {
+                            output.Add("\t" + Template.MasteringRingField + ": " + info[Template.MasteringRingField]);
+                            output.Add("\t" + Template.MasteringSIDField + ": " + info[Template.MasteringSIDField]);
+                            output.Add("\t" + Template.MouldSIDField + ": " + info[Template.MouldSIDField]);
+                            output.Add("\t" + Template.AdditionalMouldField + ": " + info[Template.AdditionalMouldField]);
+                            output.Add("\t" + Template.ToolstampField + ": " + info[Template.ToolstampField]);
+                        }
                         break;
                 }
                 output.Add(Template.BarcodeField + ": " + info[Template.BarcodeField]);
@@ -862,9 +848,13 @@ namespace DICUI.Utilities
                 }
                 switch (type)
                 {
-                    case DiscType.DVD9:
-                    case DiscType.BD50:
-                        output.Add(Template.LayerbreakField + ": " + info[Template.LayerbreakField]);
+                    case DiscType.DVD:
+                    case DiscType.BluRay:
+                        // If we have a dual-layer disc
+                        if (info.ContainsKey(Template.LayerbreakField))
+                        {
+                            output.Add(Template.LayerbreakField + ": " + info[Template.LayerbreakField]);
+                        }
                         break;
                 }
                 output.Add(Template.PVDField + ":"); output.Add("");

--- a/Utilities/Validation.cs
+++ b/Utilities/Validation.cs
@@ -9,22 +9,28 @@ namespace DICUI.Utilities
 {
     public static class Validation
     {
-        /// <summary>
-        /// Get a list of valid DiscTypes for a given system
-        /// </summary>
-        /// <param name="sys">KnownSystem value to check</param>
-        /// <returns>List of DiscTypes</returns>
-        public static List<DiscType?> GetValidDiscTypes(KnownSystem? sys)
+		/// <summary>
+		/// Get a list of valid DiscTypes for a given system matched to their respective names
+		/// </summary>
+		/// <param name="sys">KnownSystem value to check</param>
+		/// <returns>DiscTypes matched to enums, if possible</returns>
+		/// <remarks>
+		/// This returns a List of Tuples whose structure is as follows:
+		///		Item 1: Printable name
+		///		Item 2: DiscType mapping
+		///	If something has a "string, null" value, it should be assumed that it is a separator
+		/// </remarks>
+		public static List<Tuple<string, DiscType?>> GetValidDiscTypes(KnownSystem? sys)
         {
-            List<DiscType?> types = new List<DiscType?>();
+			List<DiscType?> types = new List<DiscType?>();
 
             switch (sys)
             {
                 #region Consoles
 
                 case KnownSystem.BandaiPlaydiaQuickInteractiveSystem:
-                    types.Add(DiscType.CD);
-                    break;
+					types.Add(DiscType.CD);
+					break;
                 case KnownSystem.BandaiApplePippin:
                     types.Add(DiscType.CD);
                     break;
@@ -364,7 +370,7 @@ namespace DICUI.Utilities
                     break;
             }
 
-            return types;
+            return types.Select(i => new Tuple<string, DiscType?>(Converters.DiscTypeToString(i), i)).ToList();
         }
 
         /// <summary>
@@ -411,21 +417,6 @@ namespace DICUI.Utilities
             }
 
             return mapping;
-        }
-
-        /// <summary>
-        /// Create a list of all actually used DiskTypes for current Knownystem list
-        /// </summary>
-        /// TODO: Maybe wrap this in directly to GetValidDiscTypes?
-        public static List<Tuple<string, DiscType?>> CreateListOfDiscTypesForKnownSystems(List<KnownSystem?> systems)
-        {
-            return systems
-                .ConvertAll(s => GetValidDiscTypes(s))
-                .SelectMany(d => d)
-                .Distinct()
-                .Select(d => Tuple.Create(Converters.DiscTypeToString(d), d))
-                .OrderBy(t => t.Item1)
-                .ToList();
         }
 
         /// <summary>

--- a/Utilities/Validation.cs
+++ b/Utilities/Validation.cs
@@ -39,21 +39,19 @@ namespace DICUI.Utilities
                     break;
                 case KnownSystem.MicrosoftXBOX:
                     types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.MicrosoftXBOX360XDG2:
                     types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD9);
-                    types.Add(DiscType.HDDVD);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.MicrosoftXBOX360XDG3:
                     types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     types.Add(DiscType.HDDVD);
                     break;
                 case KnownSystem.MicrosoftXBOXOne:
-                    types.Add(DiscType.BD25);
-                    types.Add(DiscType.BD50);
+                    types.Add(DiscType.BluRay);
                     break;
                 case KnownSystem.NECPCEngineTurboGrafxCD:
                     types.Add(DiscType.CD);
@@ -93,29 +91,25 @@ namespace DICUI.Utilities
                     break;
                 case KnownSystem.SonyPlayStation2:
                     types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.SonyPlayStation3:
-                    types.Add(DiscType.BD25);
-                    types.Add(DiscType.BD50);
+                    types.Add(DiscType.BluRay);
                     break;
                 case KnownSystem.SonyPlayStation4:
-                    types.Add(DiscType.BD25);
-                    types.Add(DiscType.BD50);
+                    types.Add(DiscType.BluRay);
                     break;
                 case KnownSystem.SonyPlayStationPortable:
                     types.Add(DiscType.UMD);
                     break;
                 case KnownSystem.VMLabsNuon:
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.VTechVFlashVSmilePro:
                     types.Add(DiscType.CD);
                     break;
                 case KnownSystem.ZAPiTGamesGameWaveFamilyEntertainmentSystem:
-                    types.Add(DiscType.DVD5);
+                    types.Add(DiscType.DVD);
                     break;
 
                 #endregion
@@ -127,8 +121,7 @@ namespace DICUI.Utilities
                     break;
                 case KnownSystem.AppleMacintosh:
                     types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     types.Add(DiscType.Floppy);
                     break;
                 case KnownSystem.CommodoreAmigaCD:
@@ -139,8 +132,7 @@ namespace DICUI.Utilities
                     break;
                 case KnownSystem.IBMPCCompatible:
                     types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     types.Add(DiscType.Floppy);
                     break;
                 case KnownSystem.NECPC88:
@@ -185,20 +177,17 @@ namespace DICUI.Utilities
                     types.Add(DiscType.CD);
                     break;
                 case KnownSystem.GlobalVRVortekV3:
-                    types.Add(DiscType.DVD5); // TODO: Confirm
-                    types.Add(DiscType.DVD9); // TODO: Confirm
+                    types.Add(DiscType.DVD); // TODO: Confirm
                     break;
                 case KnownSystem.ICEPCHardware:
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.IncredibleTechnologiesEagle:
                     types.Add(DiscType.CD);
                     break;
                 case KnownSystem.IncredibleTechnologiesVarious:
                     types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.KonamiFirebeat:
                     types.Add(DiscType.CD);
@@ -210,12 +199,10 @@ namespace DICUI.Utilities
                     types.Add(DiscType.CD);
                     break;
                 case KnownSystem.KonamiPython:
-                    types.Add(DiscType.DVD5); // TODO: Confirm
-                    types.Add(DiscType.DVD9); // TODO: Confirm
+                    types.Add(DiscType.DVD); // TODO: Confirm
                     break;
                 case KnownSystem.KonamiPython2:
-                    types.Add(DiscType.DVD5); // TODO: Confirm
-                    types.Add(DiscType.DVD9); // TODO: Confirm
+                    types.Add(DiscType.DVD); // TODO: Confirm
                     break;
                 case KnownSystem.KonamiSystem573:
                     types.Add(DiscType.CD);
@@ -225,8 +212,7 @@ namespace DICUI.Utilities
                     break;
                 case KnownSystem.KonamiVarious:
                     types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.MeritIndustriesBoardwalk:
                     types.Add(DiscType.CD); // TODO: Confirm
@@ -236,28 +222,23 @@ namespace DICUI.Utilities
                     break;
                 case KnownSystem.MeritIndustriesMegaTouchForce:
                     types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.MeritIndustriesMegaTouchION:
                     types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.MeritIndustriesMegaTouchMaxx:
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.MeritIndustriesMegaTouchXL:
                     types.Add(DiscType.CD);
                     break;
                 case KnownSystem.NamcoCapcomSystem256:
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.NamcoCapcomTaitoSystem246:
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.NamcoSegaNintendoTriforce:
                     types.Add(DiscType.GDROM);
@@ -266,10 +247,8 @@ namespace DICUI.Utilities
                     types.Add(DiscType.CD);
                     break;
                 case KnownSystem.NamcoSystem357:
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
-                    types.Add(DiscType.BD25);
-                    types.Add(DiscType.BD50);
+                    types.Add(DiscType.DVD);
+                    types.Add(DiscType.BluRay);
                     break;
                 case KnownSystem.NewJatreCDi:
                     types.Add(DiscType.CD);
@@ -281,26 +260,22 @@ namespace DICUI.Utilities
                     types.Add(DiscType.CD);
                     break;
                 case KnownSystem.NichibutsuXRateSystem:
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.PhotoPlayVarious:
                     types.Add(DiscType.CD);
                     break;
                 case KnownSystem.RawThrillsVarious:
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.SegaChihiro:
                     types.Add(DiscType.GDROM);
                     break;
                 case KnownSystem.SegaEuropaR:
-                    types.Add(DiscType.DVD5); // TODO: Confirm
-                    types.Add(DiscType.DVD9); // TODO: Confirm
+                    types.Add(DiscType.DVD); // TODO: Confirm
                     break;
                 case KnownSystem.SegaLindbergh:
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.SegaNaomi:
                     types.Add(DiscType.GDROM);
@@ -309,22 +284,17 @@ namespace DICUI.Utilities
                     types.Add(DiscType.GDROM);
                     break;
                 case KnownSystem.SegaNu:
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
-                    types.Add(DiscType.BD25);
-                    types.Add(DiscType.BD50);
+                    types.Add(DiscType.DVD);
+                    types.Add(DiscType.BluRay);
                     break;
                 case KnownSystem.SegaRingEdge:
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.SegaRingEdge2:
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.SegaRingWide:
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.SegaSTV:
                     types.Add(DiscType.CD);
@@ -333,8 +303,7 @@ namespace DICUI.Utilities
                     types.Add(DiscType.CD);
                     break;
                 case KnownSystem.SeibuCATSSystem:
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.TABAustriaQuizard:
                     types.Add(DiscType.CD);
@@ -354,15 +323,16 @@ namespace DICUI.Utilities
                     types.Add(DiscType.CD);
                     break;
                 case KnownSystem.BDVideo:
-                    types.Add(DiscType.BD25);
-                    types.Add(DiscType.BD50);
+                    types.Add(DiscType.BluRay);
                     break;
                 case KnownSystem.DVDVideo:
-                    types.Add(DiscType.DVD5);
-                    types.Add(DiscType.DVD9);
+                    types.Add(DiscType.DVD);
                     break;
                 case KnownSystem.EnhancedCD:
                     types.Add(DiscType.CD);
+                    break;
+                case KnownSystem.HDDVDVideo:
+                    types.Add(DiscType.HDDVD);
                     break;
                 case KnownSystem.PalmOS:
                     types.Add(DiscType.CD);
@@ -446,6 +416,7 @@ namespace DICUI.Utilities
         /// <summary>
         /// Create a list of all actually used DiskTypes for current Knownystem list
         /// </summary>
+        /// TODO: Maybe wrap this in directly to GetValidDiscTypes?
         public static List<Tuple<string, DiscType?>> CreateListOfDiscTypesForKnownSystems(List<KnownSystem?> systems)
         {
             return systems


### PR DESCRIPTION
This PR addresses the following:

- Fixes #52 - This needs testing, but I have combined the single- and dual-layer disc types into a single enum value each. This is achieved by checking for the presence of the layerbreak field in the output data. At the moment, this means that it is entirely transparent to the user what type of disc this is. Followup item (possibly for this PR): Output the disc type to either the name of the file OR a field within the submission info file.
- Fixes #53 - A few more undumpable formats have been added to the internal list along with the migration of HD-DVD out of the valid formats for X360 (XDG2/3). This should address any semantic issues as well as allow for some fairly interesting cases later when more options arise besides DIC to backup media.
- Cleanup and bugfixes for the split system and disc types. The code was good, I just had a couple of cleanups to reduce the amount of duplicate code and one null fix that was missed in the initial PR.