### PR TITLE
Add system and media type to output submission info

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -72,11 +72,11 @@
         public const string TitleField = "Title";
         public const string DiscNumberField = "Disc Number / Letter";
         public const string DiscTitleField = "Disc Title";
+        public const string SystemField = "System";
+        public const string MediaTypeField = "Media Type";
         public const string CategoryField = "Category";
         public const string RegionField = "Region";
         public const string LanguagesField = "Languages";
-        public const string SystemField = "System";
-        public const string MediaTypeField = "Media Type";
         public const string DiscSerialField = "Disc Serial";
         public const string BarcodeField = "Barcode";
         public const string ISBNField = "ISBN";

--- a/Constants.cs
+++ b/Constants.cs
@@ -75,6 +75,8 @@
         public const string CategoryField = "Category";
         public const string RegionField = "Region";
         public const string LanguagesField = "Languages";
+        public const string SystemField = "System";
+        public const string MediaTypeField = "Media Type";
         public const string DiscSerialField = "Disc Serial";
         public const string BarcodeField = "Barcode";
         public const string ISBNField = "ISBN";

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -117,8 +116,6 @@ namespace DICUI
             _optionsWindow.WindowStartupLocation = WindowStartupLocation.CenterOwner;
             _optionsWindow.Refresh();
             _optionsWindow.Show();
-
-            
         }
 
         private void txt_OutputFilename_TextChanged(object sender, TextChangedEventArgs e)

--- a/Utilities/DumpInformation.cs
+++ b/Utilities/DumpInformation.cs
@@ -137,6 +137,8 @@ namespace DICUI.Utilities
                 { Template.TitleField, Template.RequiredValue },
                 { Template.DiscNumberField, Template.OptionalValue },
                 { Template.DiscTitleField, Template.OptionalValue },
+                { Template.SystemField, Converters.KnownSystemToString(sys) },
+                { Template.MediaTypeField, Converters.DiscTypeToString(type) },
                 { Template.CategoryField, "Games" },
                 { Template.RegionField, "World (CHANGE THIS)" },
                 { Template.LanguagesField, "Klingon (CHANGE THIS)" },
@@ -212,6 +214,15 @@ namespace DICUI.Utilities
                     // If we have a single-layer disc
                     if (layerbreak == null)
                     {
+                        switch (type)
+                        {
+                            case DiscType.DVD:
+                                mappings[Template.MediaTypeField] += "-5";
+                                break;
+                            case DiscType.BluRay:
+                                mappings[Template.MediaTypeField] += "-25";
+                                break;
+                        }
                         mappings[Template.MasteringRingField] = Template.RequiredIfExistsValue;
                         mappings[Template.MasteringSIDField] = Template.RequiredIfExistsValue;
                         mappings[Template.MouldSIDField] = Template.RequiredIfExistsValue;
@@ -222,6 +233,15 @@ namespace DICUI.Utilities
                     // If we have a dual-layer disc
                     else
                     {
+                        switch (type)
+                        {
+                            case DiscType.DVD:
+                                mappings[Template.MediaTypeField] += "-9";
+                                break;
+                            case DiscType.BluRay:
+                                mappings[Template.MediaTypeField] += "-50";
+                                break;
+                        }
                         mappings["Outer " + Template.MasteringRingField] = Template.RequiredIfExistsValue;
                         mappings["Inner " + Template.MasteringRingField] = Template.RequiredIfExistsValue;
                         mappings["Outer " + Template.MasteringSIDField] = Template.RequiredIfExistsValue;
@@ -770,6 +790,8 @@ namespace DICUI.Utilities
                 output.Add(Template.TitleField + ": " + info[Template.TitleField]);
                 output.Add(Template.DiscNumberField + ": " + info[Template.DiscNumberField]);
                 output.Add(Template.DiscTitleField + ": " + info[Template.DiscTitleField]);
+                output.Add(Template.SystemField + ": " + info[Template.SystemField]);
+                output.Add(Template.MediaTypeField + ": " + info[Template.MediaTypeField]);
                 output.Add(Template.CategoryField + ": " + info[Template.CategoryField]);
                 output.Add(Template.RegionField + ": " + info[Template.RegionField]);
                 output.Add(Template.LanguagesField + ": " + info[Template.LanguagesField]);

--- a/Utilities/Validation.cs
+++ b/Utilities/Validation.cs
@@ -9,20 +9,20 @@ namespace DICUI.Utilities
 {
     public static class Validation
     {
-		/// <summary>
-		/// Get a list of valid DiscTypes for a given system matched to their respective names
-		/// </summary>
-		/// <param name="sys">KnownSystem value to check</param>
-		/// <returns>DiscTypes matched to enums, if possible</returns>
-		/// <remarks>
-		/// This returns a List of Tuples whose structure is as follows:
-		///		Item 1: Printable name
-		///		Item 2: DiscType mapping
-		///	If something has a "string, null" value, it should be assumed that it is a separator
-		/// </remarks>
-		public static List<Tuple<string, DiscType?>> GetValidDiscTypes(KnownSystem? sys)
+        /// <summary>
+        /// Get a list of valid DiscTypes for a given system matched to their respective names
+        /// </summary>
+        /// <param name="sys">KnownSystem value to check</param>
+        /// <returns>DiscTypes matched to enums, if possible</returns>
+        /// <remarks>
+        /// This returns a List of Tuples whose structure is as follows:
+        ///		Item 1: Printable name
+        ///		Item 2: DiscType mapping
+        ///	If something has a "string, null" value, it should be assumed that it is a separator
+        /// </remarks>
+	    public static List<Tuple<string, DiscType?>> GetValidDiscTypes(KnownSystem? sys)
         {
-			List<DiscType?> types = new List<DiscType?>();
+		    List<DiscType?> types = new List<DiscType?>();
 
             switch (sys)
             {

--- a/Utilities/Validation.cs
+++ b/Utilities/Validation.cs
@@ -20,17 +20,17 @@ namespace DICUI.Utilities
         ///		Item 2: DiscType mapping
         ///	If something has a "string, null" value, it should be assumed that it is a separator
         /// </remarks>
-	    public static List<Tuple<string, DiscType?>> GetValidDiscTypes(KnownSystem? sys)
+        public static List<Tuple<string, DiscType?>> GetValidDiscTypes(KnownSystem? sys)
         {
-		    List<DiscType?> types = new List<DiscType?>();
+            List<DiscType?> types = new List<DiscType?>();
 
             switch (sys)
             {
                 #region Consoles
 
                 case KnownSystem.BandaiPlaydiaQuickInteractiveSystem:
-					types.Add(DiscType.CD);
-					break;
+                    types.Add(DiscType.CD);
+                    break;
                 case KnownSystem.BandaiApplePippin:
                     types.Add(DiscType.CD);
                     break;

--- a/Utilities/Validation.cs
+++ b/Utilities/Validation.cs
@@ -383,6 +383,7 @@ namespace DICUI.Utilities
         ///		Item 2: KnownSystem mapping
         ///	If something has a "string, null" value, it should be assumed that it is a separator
         /// </remarks>
+        /// TODO: Figure out a way that the sections can be generated more automatically
         public static List<Tuple<string, KnownSystem?>> CreateListOfSystems()
         {
             List<Tuple<string, KnownSystem?>> mapping = new List<Tuple<string, KnownSystem?>>();


### PR DESCRIPTION
Add the system and media type to the output submission info. This also entails putting the proper postfix on the DVD and BD outputs to denote which type it should be submitted as in the New Disc form. Fixes #62 