### PR TITLE
Bits and Pieces

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -1,0 +1,62 @@
+### 1.06 (2018-06-15)
+
+- Fixed not being able to use the `/c2` flag properly
+- Fixed times when the ability to start dumping was improperly allowed
+- Added full support for XBOX and XBOX360 (XDG1, XDG2) dumping through DIC (using a Kreon, or presumably a 0800)
+
+### 1.05a (2018-06-14)
+
+- Fixed some ordering and nullability issues
+- Added automatic fields for PS1, PS2, Saturn
+
+### 1.05 (2018-06-14)
+
+- Miscellaneous fixes around custom parameter validation, dump information accuracy, settings window, and TODO cleanup
+- Add many more supported platforms, mostly arcade (based on publicly available information)
+- Add floppy disk dumping support
+- Add optional disc eject on completion
+- Add subdump for Sega Saturn
+- Fully support newest version of DIC including all new flags and commands
+- PlayStation and Saturn discs still don't have all internal information automatically generated
+
+### 1.04b (2018-06-13)
+
+- Added subIntention reading
+- Fixed extra extensions being appended
+- Fixed internationalization error (number formatting)
+- Fixed "Custom Input" not working
+
+### 1.04a (2018-06-13)
+
+- Fixed issue with empty trays
+- Added settings dialog
+
+### 1.04 (2018-06-13)
+
+- Behind-the-scenes fixes and formatting
+- Better checks for external programs
+- Automatically changing disc information
+- Custom parameters (and parameter validation)
+- Automatic drive speed selection
+- Automatic submission information creation
+- Add ability to stop a dump from the UI
+
+### 1.03 (2018-06-08)
+
+- edccchk now run on all CD-Roms
+- Discs unsupported by Windows are now regonized
+- Extra \ when accepting default save has been removed.
+ 
+### 1.02b (2018-05-18)
+
+- Added missing DLL
+
+### 1.02 (2018-05-18)
+
+- Fixed XBOX One and PS4 Drive Speed issue.
+- Started implementing DiscImageCreator Path selection.
+- Conforming my naming for objects and variable
+
+### 1.01d (2018-05-18)
+
+-Combine IBM PC-CD options, misc fixes.

--- a/Constants.cs
+++ b/Constants.cs
@@ -7,6 +7,7 @@
     {
         public const string StartDumping = "Start Dumping";
         public const string StopDumping = "Stop Dumping";
+        public const string FloppyDriveString = "<<FLOPPY>>";
     }
 
     /// <summary>

--- a/DICUI.csproj
+++ b/DICUI.csproj
@@ -91,6 +91,8 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Constants.cs" />
+    <Compile Include="External\OrderedDictionary.cs" />
+    <Compile Include="External\IOrderedDictionary.cs" />
     <Compile Include="Options.cs" />
     <Compile Include="Utilities\DumpInformation.cs" />
     <Compile Include="Utilities\Validation.cs" />

--- a/Enumerations.cs
+++ b/Enumerations.cs
@@ -1,9 +1,9 @@
 ﻿namespace DICUI
 {
     /// <summary>
-    /// Known disc types
+    /// Known media types
     /// </summary>
-    public enum DiscType
+    public enum MediaType
     {
         // Generic Optical Formats
         NONE = 0,

--- a/Enumerations.cs
+++ b/Enumerations.cs
@@ -15,16 +15,16 @@
         LaserDisc,
 
         // Special Optical Formats
-        CED,
         GameCubeGameDisc,
         WiiOpticalDisc,
         WiiUOpticalDisc,
         UMD,
-        
+
         // Non-Optical Formats
         Floppy,
-        Cassette,
         Cartridge,
+        Cassette,
+        CED,
     }
 
     /// <summary>

--- a/External/IOrderedDictionary.cs
+++ b/External/IOrderedDictionary.cs
@@ -3,8 +3,8 @@ using System.Collections.Specialized;
 
 namespace DICUI.External
 {
-	// Adapted from https://www.codeproject.com/Articles/18615/OrderedDictionary-T-A-generic-implementation-of-IO
-	public interface IOrderedDictionary<TKey, TValue> : IOrderedDictionary, IDictionary<TKey, TValue>
-	{
-	}
+    // Adapted from https://www.codeproject.com/Articles/18615/OrderedDictionary-T-A-generic-implementation-of-IO
+    public interface IOrderedDictionary<TKey, TValue> : IOrderedDictionary, IDictionary<TKey, TValue>
+    {
+    }
 }

--- a/External/IOrderedDictionary.cs
+++ b/External/IOrderedDictionary.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+
+namespace DICUI.External
+{
+	// Adapted from https://www.codeproject.com/Articles/18615/OrderedDictionary-T-A-generic-implementation-of-IO
+	public interface IOrderedDictionary<TKey, TValue> : IOrderedDictionary, IDictionary<TKey, TValue>
+	{
+	}
+}

--- a/External/OrderedDictionary.cs
+++ b/External/OrderedDictionary.cs
@@ -5,308 +5,322 @@ using System.Collections.Specialized;
 
 namespace DICUI.External
 {
-	// Adapted from https://www.codeproject.com/Articles/18615/OrderedDictionary-T-A-generic-implementation-of-IO
-	public class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, TValue>
-	{
-		private List<KeyValuePair<TKey, TValue>> _list;
-		private Dictionary<TKey, TValue> _dictionary;
-		private int _count;
+    // Adapted from https://www.codeproject.com/Articles/18615/OrderedDictionary-T-A-generic-implementation-of-IO
+    public class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, TValue>
+    {
+        private List<KeyValuePair<TKey, TValue>> _list;
+        private Dictionary<TKey, TValue> _dictionary;
 
-		int ICollection.Count => _count;
-		int ICollection<KeyValuePair<TKey, TValue>>.Count => _count;
+		#region Interface properties
 
-		ICollection IDictionary.Keys => _dictionary.Keys;
-		ICollection<TKey> IDictionary<TKey, TValue>.Keys => _dictionary.Keys;
+		public int Count { get; }
 
-		ICollection IDictionary.Values => _dictionary.Values;
-		ICollection<TValue> IDictionary<TKey, TValue>.Values => _dictionary.Values;
+		int ICollection.Count => Count;
+        int ICollection<KeyValuePair<TKey, TValue>>.Count => Count;
 
-		bool IDictionary.IsReadOnly => false;
-		bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
+        ICollection IDictionary.Keys => _dictionary.Keys;
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys => _dictionary.Keys;
 
-		bool IDictionary.IsFixedSize => false;
+        ICollection IDictionary.Values => _dictionary.Values;
+        ICollection<TValue> IDictionary<TKey, TValue>.Values => _dictionary.Values;
 
-		object ICollection.SyncRoot => new object();
+        bool IDictionary.IsReadOnly => false;
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
 
-		bool ICollection.IsSynchronized => true;
+        bool IDictionary.IsFixedSize => false;
 
-		public TValue this[int index]
-		{
-			get
-			{
-				return _list[index].Value;
-			}
-			set
-			{
-				if (index >= _count || index < 0)
-					throw new ArgumentOutOfRangeException("index",
-						  "'index' must be non-negative and less than" +
-						  " the size of the collection");
+        object ICollection.SyncRoot => new object();
 
-				TKey key = _list[index].Key;
+        bool ICollection.IsSynchronized => true;
 
-				_list[index] = new KeyValuePair<TKey, TValue>(key, value);
-				_dictionary[key] = value;
-			}
-		}
+        public TValue this[int index]
+        {
+            get
+            {
+                return _list[index].Value;
+            }
+            set
+            {
+                if (index >= Count || index < 0)
+                    throw new ArgumentOutOfRangeException("index",
+                          "'index' must be non-negative and less than" +
+                          " the size of the collection");
 
-		object IOrderedDictionary.this[int index]
-		{
-			get
-			{
-				return _list[index].Value;
-			}
-			set
-			{
-				if (index >= _count || index < 0)
-					throw new ArgumentOutOfRangeException("index",
-						  "'index' must be non-negative and less than" +
-						  " the size of the collection");
+                TKey key = _list[index].Key;
 
-				var valueObj = (TValue)value;
-				if (valueObj == null)
-					throw new ArgumentException($"Value must be of type {typeof(TValue)}");
+                _list[index] = new KeyValuePair<TKey, TValue>(key, value);
+                _dictionary[key] = value;
+            }
+        }
 
-				TKey key = _list[index].Key;
+        object IOrderedDictionary.this[int index]
+        {
+            get
+            {
+                return _list[index].Value;
+            }
+            set
+            {
+                if (index >= Count || index < 0)
+                    throw new ArgumentOutOfRangeException("index",
+                          "'index' must be non-negative and less than" +
+                          " the size of the collection");
 
-				_list[index] = new KeyValuePair<TKey, TValue>(key, valueObj);
-				_dictionary[key] = valueObj;
-			}
-		}
+                var valueObj = (TValue)value;
+                if (valueObj == null)
+                    throw new ArgumentException($"Value must be of type {typeof(TValue)}");
 
-		object IDictionary.this[object key]
-		{
-			get
-			{
-				var keyObj = (TKey)key;
-				if (keyObj == null)
-					throw new ArgumentException($"Key must be of type {typeof(TKey)}");
+                TKey key = _list[index].Key;
 
-				return _dictionary[keyObj];
-			}
-			set
-			{
-				var keyObj = (TKey)key;
-				if (keyObj == null)
-					throw new ArgumentException($"Key must be of type {typeof(TKey)}");
+                _list[index] = new KeyValuePair<TKey, TValue>(key, valueObj);
+                _dictionary[key] = valueObj;
+            }
+        }
 
-				var valueObj = (TValue)value;
-				if (valueObj == null)
-					throw new ArgumentException($"Value must be of type {typeof(TValue)}");
+        object IDictionary.this[object key]
+        {
+            get
+            {
+                var keyObj = (TKey)key;
+                if (keyObj == null)
+                    throw new ArgumentException($"Key must be of type {typeof(TKey)}");
 
-				if (_dictionary.ContainsKey(keyObj))
-				{
-					_dictionary[keyObj] = valueObj;
-					_list[IndexOfKey(keyObj)] = new KeyValuePair<TKey, TValue>(keyObj, valueObj);
-				}
-				else
-				{
-					Add(keyObj, valueObj);
-				}
-			}
-		}
+                return _dictionary[keyObj];
+            }
+            set
+            {
+                var keyObj = (TKey)key;
+                if (keyObj == null)
+                    throw new ArgumentException($"Key must be of type {typeof(TKey)}");
 
-		TValue IDictionary<TKey, TValue>.this[TKey key]
-		{
-			get
-			{
-				return _dictionary[key];
-			}
-			set
-			{
-				if (_dictionary.ContainsKey(key))
-				{
-					_dictionary[key] = value;
-					_list[IndexOfKey(key)] = new KeyValuePair<TKey, TValue>(key, value);
-				}
-				else
-				{
-					Add(key, value);
-				}
-			}
-		}
+                var valueObj = (TValue)value;
+                if (valueObj == null)
+                    throw new ArgumentException($"Value must be of type {typeof(TValue)}");
 
-		public OrderedDictionary()
-		{
-			_list = new List<KeyValuePair<TKey, TValue>>();
-			_dictionary = new Dictionary<TKey, TValue>();
-			_count = 0;
-		}
+                if (_dictionary.ContainsKey(keyObj))
+                {
+                    _dictionary[keyObj] = valueObj;
+                    _list[IndexOfKey(keyObj)] = new KeyValuePair<TKey, TValue>(keyObj, valueObj);
+                }
+                else
+                {
+                    Add(keyObj, valueObj);
+                }
+            }
+        }
 
-		public int Add(TKey key, TValue value)
-		{
-			_dictionary.Add(key, value);
-			_list.Add(new KeyValuePair<TKey, TValue>(key, value));
-			return _count - 1;
-		}
+        TValue IDictionary<TKey, TValue>.this[TKey key]
+        {
+            get
+            {
+                return _dictionary[key];
+            }
+            set
+            {
+                if (_dictionary.ContainsKey(key))
+                {
+                    _dictionary[key] = value;
+                    _list[IndexOfKey(key)] = new KeyValuePair<TKey, TValue>(key, value);
+                }
+                else
+                {
+                    Add(key, value);
+                }
+            }
+        }
 
-		public void Insert(int index, TKey key, TValue value)
-		{
-			if (index > _count || index < 0)
-				throw new ArgumentOutOfRangeException("index");
+        #endregion
 
-			_dictionary.Add(key, value);
-			_list.Insert(index, new KeyValuePair<TKey, TValue>(key, value));
-		}
+        public OrderedDictionary()
+        {
+            _list = new List<KeyValuePair<TKey, TValue>>();
+            _dictionary = new Dictionary<TKey, TValue>();
+            Count = 0;
+        }
 
-		void IOrderedDictionary.RemoveAt(int index)
-		{
-			if (index >= _count || index < 0)
-				throw new ArgumentOutOfRangeException("index",
-					  "'index' must be non-negative and less than " +
-					  "the size of the collection");
+        public int Add(TKey key, TValue value)
+        {
+            _dictionary.Add(key, value);
+            _list.Add(new KeyValuePair<TKey, TValue>(key, value));
+            return Count - 1;
+        }
 
-			TKey key = _list[index].Key;
+        public void Insert(int index, TKey key, TValue value)
+        {
+            if (index > Count || index < 0)
+                throw new ArgumentOutOfRangeException("index");
 
-			_list.RemoveAt(index);
-			_dictionary.Remove(key);
-		}
+            _dictionary.Add(key, value);
+            _list.Insert(index, new KeyValuePair<TKey, TValue>(key, value));
+        }
 
-		public bool Remove(TKey key)
-		{
-			if (null == key)
-				throw new ArgumentNullException("key");
+        void IOrderedDictionary.RemoveAt(int index)
+        {
+            if (index >= Count || index < 0)
+                throw new ArgumentOutOfRangeException("index",
+                      "'index' must be non-negative and less than " +
+                      "the size of the collection");
 
-			int index = IndexOfKey(key);
-			if (index >= 0)
-			{
-				if (_dictionary.Remove(key))
-				{
-					_list.RemoveAt(index);
-					return true;
-				}
-			}
-			return false;
-		}
+            TKey key = _list[index].Key;
 
-		private int IndexOfKey(TKey key)
-		{
-			return _list.FindIndex(kvp => kvp.Key.Equals(key));
-		}
+            _list.RemoveAt(index);
+            _dictionary.Remove(key);
+        }
 
-		IDictionaryEnumerator IOrderedDictionary.GetEnumerator()
-		{
-			return _dictionary.GetEnumerator();
-		}
+        public bool Remove(TKey key)
+        {
+            if (null == key)
+                throw new ArgumentNullException("key");
 
-		void IOrderedDictionary.Insert(int index, object key, object value)
-		{
-			var keyObj = (TKey)key;
-			if (keyObj == null)
-				throw new ArgumentException($"Key must be of type {typeof(TKey)}");
+            int index = IndexOfKey(key);
+            if (index >= 0)
+            {
+                if (_dictionary.Remove(key))
+                {
+                    _list.RemoveAt(index);
+                    return true;
+                }
+            }
+            return false;
+        }
 
-			var valueObj = (TValue)value;
-			if (valueObj == null)
-				throw new ArgumentException($"Value must be of type {typeof(TValue)}");
+        public bool ContainsKey(TKey key)
+        {
+            return _dictionary.ContainsKey(key);
+        }
 
-			Insert(index, keyObj, valueObj);
-		}
+        private int IndexOfKey(TKey key)
+        {
+            return _list.FindIndex(kvp => kvp.Key.Equals(key));
+        }
 
-		bool IDictionary.Contains(object key)
-		{
-			var keyObj = (TKey)key;
-			if (keyObj == null)
-				throw new ArgumentException($"Key must be of type {typeof(TKey)}");
+        #region Interface methods
 
-			return _dictionary.ContainsKey(keyObj);
-		}
+        IDictionaryEnumerator IOrderedDictionary.GetEnumerator()
+        {
+            return _dictionary.GetEnumerator();
+        }
 
-		void IDictionary.Add(object key, object value)
-		{
-			var keyObj = (TKey)key;
-			if (keyObj == null)
-				throw new ArgumentException($"Key must be of type {typeof(TKey)}");
+        void IOrderedDictionary.Insert(int index, object key, object value)
+        {
+            var keyObj = (TKey)key;
+            if (keyObj == null)
+                throw new ArgumentException($"Key must be of type {typeof(TKey)}");
 
-			var valueObj = (TValue)value;
-			if (valueObj == null)
-				throw new ArgumentException($"Value must be of type {typeof(TValue)}");
+            var valueObj = (TValue)value;
+            if (valueObj == null)
+                throw new ArgumentException($"Value must be of type {typeof(TValue)}");
 
-			Add(keyObj, valueObj);
-		}
+            Insert(index, keyObj, valueObj);
+        }
 
-		void IDictionary.Clear()
-		{
-			_dictionary.Clear();
-			_list.Clear();
-		}
+        bool IDictionary.Contains(object key)
+        {
+            var keyObj = (TKey)key;
+            if (keyObj == null)
+                throw new ArgumentException($"Key must be of type {typeof(TKey)}");
 
-		IDictionaryEnumerator IDictionary.GetEnumerator()
-		{
-			return _dictionary.GetEnumerator();
-		}
+            return _dictionary.ContainsKey(keyObj);
+        }
 
-		void IDictionary.Remove(object key)
-		{
-			var keyObj = (TKey)key;
-			if (keyObj == null)
-				throw new ArgumentException($"Key must be of type {typeof(TKey)}");
+        void IDictionary.Add(object key, object value)
+        {
+            var keyObj = (TKey)key;
+            if (keyObj == null)
+                throw new ArgumentException($"Key must be of type {typeof(TKey)}");
 
-			Remove(keyObj);
-		}
+            var valueObj = (TValue)value;
+            if (valueObj == null)
+                throw new ArgumentException($"Value must be of type {typeof(TValue)}");
 
-		void ICollection.CopyTo(Array array, int index)
-		{
-			var arrayObj = array as KeyValuePair<TKey, TValue>[];
-			if (arrayObj == null)
-				throw new ArgumentException($"Key must be of type {typeof(KeyValuePair<TKey, TValue>[])}");
+            Add(keyObj, valueObj);
+        }
 
-			_list.CopyTo(arrayObj, index);
-		}
+        void IDictionary.Clear()
+        {
+            _dictionary.Clear();
+            _list.Clear();
+        }
 
-		bool IDictionary<TKey, TValue>.ContainsKey(TKey key)
-		{
-			return _dictionary.ContainsKey(key);
-		}
+        IDictionaryEnumerator IDictionary.GetEnumerator()
+        {
+            return _dictionary.GetEnumerator();
+        }
 
-		void IDictionary<TKey, TValue>.Add(TKey key, TValue value)
-		{
-			Add(key, value);
-		}
+        void IDictionary.Remove(object key)
+        {
+            var keyObj = (TKey)key;
+            if (keyObj == null)
+                throw new ArgumentException($"Key must be of type {typeof(TKey)}");
 
-		bool IDictionary<TKey, TValue>.Remove(TKey key)
-		{
-			return Remove(key);
-		}
+            Remove(keyObj);
+        }
 
-		bool IDictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value)
-		{
-			return _dictionary.TryGetValue(key, out value);
-		}
+        void ICollection.CopyTo(Array array, int index)
+        {
+            var arrayObj = array as KeyValuePair<TKey, TValue>[];
+            if (arrayObj == null)
+                throw new ArgumentException($"Key must be of type {typeof(KeyValuePair<TKey, TValue>[])}");
 
-		void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
-		{
-			Add(item.Key, item.Value);
-		}
+            _list.CopyTo(arrayObj, index);
+        }
 
-		void ICollection<KeyValuePair<TKey, TValue>>.Clear()
-		{
-			_dictionary.Clear();
-			_list.Clear();
-		}
+        bool IDictionary<TKey, TValue>.ContainsKey(TKey key)
+        {
+            return ContainsKey(key);
+        }
 
-		bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item)
-		{
-			return _list.Contains(item);
-		}
+        void IDictionary<TKey, TValue>.Add(TKey key, TValue value)
+        {
+            Add(key, value);
+        }
 
-		void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
-		{
-			_list.CopyTo(array, arrayIndex);
-		}
+        bool IDictionary<TKey, TValue>.Remove(TKey key)
+        {
+            return Remove(key);
+        }
 
-		bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
-		{
-			return Remove(item.Key);
-		}
+        bool IDictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value)
+        {
+            return _dictionary.TryGetValue(key, out value);
+        }
 
-		IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
-		{
-			return _list.GetEnumerator();
-		}
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
+        {
+            Add(item.Key, item.Value);
+        }
 
-		IEnumerator IEnumerable.GetEnumerator()
-		{
-			return _list.GetEnumerator();
-		}
-	}
+        void ICollection<KeyValuePair<TKey, TValue>>.Clear()
+        {
+            _dictionary.Clear();
+            _list.Clear();
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return _list.Contains(item);
+        }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            _list.CopyTo(array, arrayIndex);
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
+        {
+            return Remove(item.Key);
+        }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+        {
+            return _list.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _list.GetEnumerator();
+        }
+
+        #endregion
+    }
 }

--- a/External/OrderedDictionary.cs
+++ b/External/OrderedDictionary.cs
@@ -1,0 +1,312 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+
+namespace DICUI.External
+{
+	// Adapted from https://www.codeproject.com/Articles/18615/OrderedDictionary-T-A-generic-implementation-of-IO
+	public class OrderedDictionary<TKey, TValue> : IOrderedDictionary<TKey, TValue>
+	{
+		private List<KeyValuePair<TKey, TValue>> _list;
+		private Dictionary<TKey, TValue> _dictionary;
+		private int _count;
+
+		int ICollection.Count => _count;
+		int ICollection<KeyValuePair<TKey, TValue>>.Count => _count;
+
+		ICollection IDictionary.Keys => _dictionary.Keys;
+		ICollection<TKey> IDictionary<TKey, TValue>.Keys => _dictionary.Keys;
+
+		ICollection IDictionary.Values => _dictionary.Values;
+		ICollection<TValue> IDictionary<TKey, TValue>.Values => _dictionary.Values;
+
+		bool IDictionary.IsReadOnly => false;
+		bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
+
+		bool IDictionary.IsFixedSize => false;
+
+		object ICollection.SyncRoot => new object();
+
+		bool ICollection.IsSynchronized => true;
+
+		public TValue this[int index]
+		{
+			get
+			{
+				return _list[index].Value;
+			}
+			set
+			{
+				if (index >= _count || index < 0)
+					throw new ArgumentOutOfRangeException("index",
+						  "'index' must be non-negative and less than" +
+						  " the size of the collection");
+
+				TKey key = _list[index].Key;
+
+				_list[index] = new KeyValuePair<TKey, TValue>(key, value);
+				_dictionary[key] = value;
+			}
+		}
+
+		object IOrderedDictionary.this[int index]
+		{
+			get
+			{
+				return _list[index].Value;
+			}
+			set
+			{
+				if (index >= _count || index < 0)
+					throw new ArgumentOutOfRangeException("index",
+						  "'index' must be non-negative and less than" +
+						  " the size of the collection");
+
+				var valueObj = (TValue)value;
+				if (valueObj == null)
+					throw new ArgumentException($"Value must be of type {typeof(TValue)}");
+
+				TKey key = _list[index].Key;
+
+				_list[index] = new KeyValuePair<TKey, TValue>(key, valueObj);
+				_dictionary[key] = valueObj;
+			}
+		}
+
+		object IDictionary.this[object key]
+		{
+			get
+			{
+				var keyObj = (TKey)key;
+				if (keyObj == null)
+					throw new ArgumentException($"Key must be of type {typeof(TKey)}");
+
+				return _dictionary[keyObj];
+			}
+			set
+			{
+				var keyObj = (TKey)key;
+				if (keyObj == null)
+					throw new ArgumentException($"Key must be of type {typeof(TKey)}");
+
+				var valueObj = (TValue)value;
+				if (valueObj == null)
+					throw new ArgumentException($"Value must be of type {typeof(TValue)}");
+
+				if (_dictionary.ContainsKey(keyObj))
+				{
+					_dictionary[keyObj] = valueObj;
+					_list[IndexOfKey(keyObj)] = new KeyValuePair<TKey, TValue>(keyObj, valueObj);
+				}
+				else
+				{
+					Add(keyObj, valueObj);
+				}
+			}
+		}
+
+		TValue IDictionary<TKey, TValue>.this[TKey key]
+		{
+			get
+			{
+				return _dictionary[key];
+			}
+			set
+			{
+				if (_dictionary.ContainsKey(key))
+				{
+					_dictionary[key] = value;
+					_list[IndexOfKey(key)] = new KeyValuePair<TKey, TValue>(key, value);
+				}
+				else
+				{
+					Add(key, value);
+				}
+			}
+		}
+
+		public OrderedDictionary()
+		{
+			_list = new List<KeyValuePair<TKey, TValue>>();
+			_dictionary = new Dictionary<TKey, TValue>();
+			_count = 0;
+		}
+
+		public int Add(TKey key, TValue value)
+		{
+			_dictionary.Add(key, value);
+			_list.Add(new KeyValuePair<TKey, TValue>(key, value));
+			return _count - 1;
+		}
+
+		public void Insert(int index, TKey key, TValue value)
+		{
+			if (index > _count || index < 0)
+				throw new ArgumentOutOfRangeException("index");
+
+			_dictionary.Add(key, value);
+			_list.Insert(index, new KeyValuePair<TKey, TValue>(key, value));
+		}
+
+		void IOrderedDictionary.RemoveAt(int index)
+		{
+			if (index >= _count || index < 0)
+				throw new ArgumentOutOfRangeException("index",
+					  "'index' must be non-negative and less than " +
+					  "the size of the collection");
+
+			TKey key = _list[index].Key;
+
+			_list.RemoveAt(index);
+			_dictionary.Remove(key);
+		}
+
+		public bool Remove(TKey key)
+		{
+			if (null == key)
+				throw new ArgumentNullException("key");
+
+			int index = IndexOfKey(key);
+			if (index >= 0)
+			{
+				if (_dictionary.Remove(key))
+				{
+					_list.RemoveAt(index);
+					return true;
+				}
+			}
+			return false;
+		}
+
+		private int IndexOfKey(TKey key)
+		{
+			return _list.FindIndex(kvp => kvp.Key.Equals(key));
+		}
+
+		IDictionaryEnumerator IOrderedDictionary.GetEnumerator()
+		{
+			return _dictionary.GetEnumerator();
+		}
+
+		void IOrderedDictionary.Insert(int index, object key, object value)
+		{
+			var keyObj = (TKey)key;
+			if (keyObj == null)
+				throw new ArgumentException($"Key must be of type {typeof(TKey)}");
+
+			var valueObj = (TValue)value;
+			if (valueObj == null)
+				throw new ArgumentException($"Value must be of type {typeof(TValue)}");
+
+			Insert(index, keyObj, valueObj);
+		}
+
+		bool IDictionary.Contains(object key)
+		{
+			var keyObj = (TKey)key;
+			if (keyObj == null)
+				throw new ArgumentException($"Key must be of type {typeof(TKey)}");
+
+			return _dictionary.ContainsKey(keyObj);
+		}
+
+		void IDictionary.Add(object key, object value)
+		{
+			var keyObj = (TKey)key;
+			if (keyObj == null)
+				throw new ArgumentException($"Key must be of type {typeof(TKey)}");
+
+			var valueObj = (TValue)value;
+			if (valueObj == null)
+				throw new ArgumentException($"Value must be of type {typeof(TValue)}");
+
+			Add(keyObj, valueObj);
+		}
+
+		void IDictionary.Clear()
+		{
+			_dictionary.Clear();
+			_list.Clear();
+		}
+
+		IDictionaryEnumerator IDictionary.GetEnumerator()
+		{
+			return _dictionary.GetEnumerator();
+		}
+
+		void IDictionary.Remove(object key)
+		{
+			var keyObj = (TKey)key;
+			if (keyObj == null)
+				throw new ArgumentException($"Key must be of type {typeof(TKey)}");
+
+			Remove(keyObj);
+		}
+
+		void ICollection.CopyTo(Array array, int index)
+		{
+			var arrayObj = array as KeyValuePair<TKey, TValue>[];
+			if (arrayObj == null)
+				throw new ArgumentException($"Key must be of type {typeof(KeyValuePair<TKey, TValue>[])}");
+
+			_list.CopyTo(arrayObj, index);
+		}
+
+		bool IDictionary<TKey, TValue>.ContainsKey(TKey key)
+		{
+			return _dictionary.ContainsKey(key);
+		}
+
+		void IDictionary<TKey, TValue>.Add(TKey key, TValue value)
+		{
+			Add(key, value);
+		}
+
+		bool IDictionary<TKey, TValue>.Remove(TKey key)
+		{
+			return Remove(key);
+		}
+
+		bool IDictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value)
+		{
+			return _dictionary.TryGetValue(key, out value);
+		}
+
+		void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
+		{
+			Add(item.Key, item.Value);
+		}
+
+		void ICollection<KeyValuePair<TKey, TValue>>.Clear()
+		{
+			_dictionary.Clear();
+			_list.Clear();
+		}
+
+		bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item)
+		{
+			return _list.Contains(item);
+		}
+
+		void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+		{
+			_list.CopyTo(array, arrayIndex);
+		}
+
+		bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
+		{
+			return Remove(item.Key);
+		}
+
+		IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+		{
+			return _list.GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return _list.GetEnumerator();
+		}
+	}
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -42,9 +42,9 @@
                 <RowDefinition/>
             </Grid.RowDefinitions>
 
-            <Label Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Content="System/Disc Type" />
+            <Label Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Content="System/Media Type" />
             <ComboBox x:Name="cmb_SystemType" Grid.Row="0" Grid.Column="1" Height="22" Width="250" HorizontalAlignment="left" SelectionChanged="cmb_SystemType_SelectionChanged" />
-            <ComboBox x:Name="cmb_DiscType" Grid.Row="0" Grid.Column="1" Height="22" Width="140" HorizontalAlignment="right" SelectionChanged="cmb_DiscType_SelectionChanged" />
+            <ComboBox x:Name="cmb_MediaType" Grid.Row="0" Grid.Column="1" Height="22" Width="140" HorizontalAlignment="right" SelectionChanged="cmb_MediaType_SelectionChanged" />
 
             <Label Grid.Row="1" Grid.Column="0" VerticalAlignment="Center">Output Filename</Label>
             <TextBox x:Name="txt_OutputFilename" Grid.Row="1" Grid.Column="1" Height="22" TextChanged="txt_OutputFilename_TextChanged" />

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -17,7 +17,7 @@ namespace DICUI
         private List<Tuple<char, string, bool>> _drives { get; set; }
         private List<int> _driveSpeeds { get { return new List<int> { 1, 2, 3, 4, 6, 8, 12, 16, 20, 24, 32, 40, 44, 48, 52, 56, 72 }; } }
         private List<Tuple<string, KnownSystem?>> _systems { get; set; }
-        private List<Tuple<string, DiscType?>> _discTypes { get; set; }
+        private List<Tuple<string, MediaType?>> _MediaTypes { get; set; }
         private Process childProcess { get; set; }
 
         private OptionsWindow _optionsWindow;
@@ -78,11 +78,11 @@ namespace DICUI
         private void cmb_SystemType_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             GetOutputNames();
-            PopulateDiscTypeAccordingToChosenSystem();
+            PopulateMediaTypeAccordingToChosenSystem();
             EnsureDiscInformation();
         }
 
-        private void cmb_DiscType_SelectionChanged(object sencder, SelectionChangedEventArgs e)
+        private void cmb_MediaType_SelectionChanged(object sencder, SelectionChangedEventArgs e)
         {
             GetOutputNames();
             EnsureDiscInformation();
@@ -135,24 +135,24 @@ namespace DICUI
         /// <summary>
         /// Populate disc type according to system type
         /// </summary>
-        private void PopulateDiscTypeAccordingToChosenSystem()
+        private void PopulateMediaTypeAccordingToChosenSystem()
         {
             var currentSystem = cmb_SystemType.SelectedItem as Tuple<string, KnownSystem?>;
 
             if (currentSystem != null)
             {
-                _discTypes = Utilities.Validation.GetValidDiscTypes(currentSystem.Item2);
-                cmb_DiscType.ItemsSource = _discTypes;
-                cmb_DiscType.DisplayMemberPath = "Item1";
+                _MediaTypes = Utilities.Validation.GetValidMediaTypes(currentSystem.Item2);
+                cmb_MediaType.ItemsSource = _MediaTypes;
+                cmb_MediaType.DisplayMemberPath = "Item1";
 
-                cmb_DiscType.IsEnabled = _discTypes.Count > 1;
-                cmb_DiscType.SelectedIndex = 0;
+                cmb_MediaType.IsEnabled = _MediaTypes.Count > 1;
+                cmb_MediaType.SelectedIndex = 0;
             }
             else
             {
-                cmb_DiscType.IsEnabled = false;
-                cmb_DiscType.ItemsSource = null;
-                cmb_DiscType.SelectedIndex = -1;
+                cmb_MediaType.IsEnabled = false;
+                cmb_MediaType.ItemsSource = null;
+                cmb_MediaType.SelectedIndex = -1;
             }
         }
 
@@ -228,7 +228,7 @@ namespace DICUI
             // Populate all tuples
             var driveLetterTuple = cmb_DriveLetter.SelectedItem as Tuple<char, string, bool>;
             var systemTypeTuple = cmb_SystemType.SelectedValue as Tuple<string, KnownSystem?>;
-            var discTypeTuple = cmb_DiscType.SelectedValue as Tuple<string, DiscType?>;
+            var MediaTypeTuple = cmb_MediaType.SelectedValue as Tuple<string, MediaType?>;
 
             // Get the currently selected options
             string dicPath = _options.dicPath;
@@ -240,14 +240,14 @@ namespace DICUI
             string outputFilename = txt_OutputFilename.Text;
             string systemName = systemTypeTuple.Item1;
             KnownSystem? system = systemTypeTuple.Item2;
-            DiscType? type = discTypeTuple.Item2;
+            MediaType? type = MediaTypeTuple.Item2;
 
             string customParameters = txt_Parameters.Text;
 
             // Validate that everything is good
             if (string.IsNullOrWhiteSpace(customParameters)
                 || !Utilities.Validation.ValidateParameters(customParameters)
-                || (isFloppy ^ type == DiscType.Floppy))
+                || (isFloppy ^ type == MediaType.Floppy))
             {
                 lbl_Status.Content = "Error! Current configuration is not supported!";
                 btn_StartStop.Content = UIElements.StartDumping;
@@ -451,14 +451,14 @@ namespace DICUI
         private void EnsureDiscInformation()
         {
             var systemTuple = cmb_SystemType.SelectedItem as Tuple<string, KnownSystem?>;
-            var discTypeTuple = cmb_DiscType.SelectedItem as Tuple<string, DiscType?>;
+            var MediaTypeTuple = cmb_MediaType.SelectedItem as Tuple<string, MediaType?>;
 
             // If we're on a separator, go to the next item
             if (systemTuple.Item2 == null)
                 systemTuple = cmb_SystemType.Items[++cmb_SystemType.SelectedIndex] as Tuple<string, KnownSystem?>;
 
             var selectedSystem = systemTuple.Item2;
-            var selectedDiscType = discTypeTuple != null ? discTypeTuple.Item2 : DiscType.NONE;
+            var selectedMediaType = MediaTypeTuple != null ? MediaTypeTuple.Item2 : MediaType.NONE;
 
             // No system chosen, update status
             if (selectedSystem == KnownSystem.NONE)
@@ -469,52 +469,52 @@ namespace DICUI
             else if (selectedSystem != KnownSystem.Custom)
             {
                 // If we're on an unsupported type, update the status accordingly
-                switch (selectedDiscType)
+                switch (selectedMediaType)
                 {
-                    case DiscType.NONE:
+                    case MediaType.NONE:
                         lbl_Status.Content = "Please select a valid disc type";
                         btn_StartStop.IsEnabled = false;
                         break;
-                    case DiscType.GameCubeGameDisc:
-                    case DiscType.GDROM:
-                        lbl_Status.Content = string.Format("{0} discs are partially supported by DIC", discTypeTuple.Item1);
+                    case MediaType.GameCubeGameDisc:
+                    case MediaType.GDROM:
+                        lbl_Status.Content = string.Format("{0} discs are partially supported by DIC", MediaTypeTuple.Item1);
                         btn_StartStop.IsEnabled = (_drives.Count > 0 ? true : false);
                         break;
-                    case DiscType.HDDVD:
-                    case DiscType.LaserDisc:
-                    case DiscType.CED:
-                    case DiscType.UMD:
-                    case DiscType.WiiOpticalDisc:
-                    case DiscType.WiiUOpticalDisc:
-                    case DiscType.Cartridge:
-                    case DiscType.Cassette:
-                        lbl_Status.Content = string.Format("{0} discs are not currently supported by DIC", discTypeTuple.Item1);
+                    case MediaType.HDDVD:
+                    case MediaType.LaserDisc:
+                    case MediaType.CED:
+                    case MediaType.UMD:
+                    case MediaType.WiiOpticalDisc:
+                    case MediaType.WiiUOpticalDisc:
+                    case MediaType.Cartridge:
+                    case MediaType.Cassette:
+                        lbl_Status.Content = string.Format("{0} discs are not currently supported by DIC", MediaTypeTuple.Item1);
                         btn_StartStop.IsEnabled = false;
                         break;
-                    case DiscType.DVD:
+                    case MediaType.DVD:
                         if (selectedSystem == KnownSystem.MicrosoftXBOX360XDG3)
                         {
-                            lbl_Status.Content = string.Format("{0} discs are not currently supported by DIC", discTypeTuple.Item1);
+                            lbl_Status.Content = string.Format("{0} discs are not currently supported by DIC", MediaTypeTuple.Item1);
                             btn_StartStop.IsEnabled = false;
                         }
                         else
                         {
-                            lbl_Status.Content = string.Format("{0} ready to dump", discTypeTuple.Item1);
+                            lbl_Status.Content = string.Format("{0} ready to dump", MediaTypeTuple.Item1);
                             btn_StartStop.IsEnabled = (_drives.Count > 0 ? true : false);
                         }
                         break;
                     default:
-                        lbl_Status.Content = string.Format("{0} ready to dump", discTypeTuple.Item1);
+                        lbl_Status.Content = string.Format("{0} ready to dump", MediaTypeTuple.Item1);
                         btn_StartStop.IsEnabled = (_drives.Count > 0 ? true : false);
                         break;
                 }
             }
 
             // If we're in a type that doesn't support drive speeds
-            switch (selectedDiscType)
+            switch (selectedMediaType)
             {
-                case DiscType.Floppy:
-                case DiscType.BluRay:
+                case MediaType.Floppy:
+                case MediaType.BluRay:
                     cmb_DriveSpeed.IsEnabled = false;
                     break;
                 default:
@@ -552,7 +552,7 @@ namespace DICUI
                 cmb_DriveLetter.IsEnabled = true;
 
                 // Populate with the correct params for inputs (if we're not on the default option)
-                if (selectedSystem != KnownSystem.NONE && selectedDiscType != DiscType.NONE)
+                if (selectedSystem != KnownSystem.NONE && selectedMediaType != MediaType.NONE)
                 {
                     var driveletter = cmb_DriveLetter.SelectedValue as Tuple<char, string, bool>;
 
@@ -560,13 +560,13 @@ namespace DICUI
                     if (driveletter == null)
                         return;
 
-                    string discType = Converters.KnownSystemAndDiscTypeToBaseCommand(selectedSystem, selectedDiscType);
-                    List<string> defaultParams = Converters.KnownSystemAndDiscTypeToParameters(selectedSystem, selectedDiscType);
-                    txt_Parameters.Text = discType
+                    string MediaType = Converters.KnownSystemAndMediaTypeToBaseCommand(selectedSystem, selectedMediaType);
+                    List<string> defaultParams = Converters.KnownSystemAndMediaTypeToParameters(selectedSystem, selectedMediaType);
+                    txt_Parameters.Text = MediaType
                         + " " + driveletter.Item1
                         + " \"" + Path.Combine(txt_OutputDirectory.Text, txt_OutputFilename.Text) + "\" "
-                        + (selectedDiscType != DiscType.Floppy
-                            && selectedDiscType != DiscType.BluRay
+                        + (selectedMediaType != MediaType.Floppy
+                            && selectedMediaType != MediaType.BluRay
                             && selectedSystem != KnownSystem.MicrosoftXBOX
                             && selectedSystem != KnownSystem.MicrosoftXBOX360XDG2
                             && selectedSystem != KnownSystem.MicrosoftXBOX360XDG3
@@ -583,12 +583,12 @@ namespace DICUI
         {
             var driveTuple = cmb_DriveLetter.SelectedItem as Tuple<char, string, bool>;
             var systemTuple = cmb_SystemType.SelectedItem as Tuple<string, KnownSystem?>;
-            var discTuple = cmb_DiscType.SelectedItem as Tuple<string, DiscType?>;
+            var discTuple = cmb_MediaType.SelectedItem as Tuple<string, MediaType?>;
 
             if (driveTuple != null && systemTuple != null && discTuple != null)
             {
                 txt_OutputDirectory.Text = Path.Combine(_options.defaultOutputPath, driveTuple.Item2);
-                txt_OutputFilename.Text = driveTuple.Item2 + Converters.DiscTypeToExtension(discTuple.Item2);
+                txt_OutputFilename.Text = driveTuple.Item2 + Converters.MediaTypeToExtension(discTuple.Item2);
             }
             else
             {

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
@@ -267,6 +268,11 @@ namespace DICUI
                 outputDirectory = Path.GetDirectoryName(path);
                 outputFilename = Path.GetFileName(path);
             }
+
+            // Replace characters where needed
+            // TODO: Investigate why the `&` replacement is needed
+            outputDirectory = outputDirectory.Replace('.', '_').Replace('&', '_');
+            outputFilename = new StringBuilder(outputFilename.Replace('&', '_')).Replace('.', '_', 0, outputFilename.LastIndexOf('.')).ToString();
 
             // Validate that the required program exits
             if (!File.Exists(dicPath))

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -560,9 +560,9 @@ namespace DICUI
                     if (driveletter == null)
                         return;
 
-                    string MediaType = Converters.KnownSystemAndMediaTypeToBaseCommand(selectedSystem, selectedMediaType);
+                    string command = Converters.KnownSystemAndMediaTypeToBaseCommand(selectedSystem, selectedMediaType);
                     List<string> defaultParams = Converters.KnownSystemAndMediaTypeToParameters(selectedSystem, selectedMediaType);
-                    txt_Parameters.Text = MediaType
+                    txt_Parameters.Text = command
                         + " " + driveletter.Item1
                         + " \"" + Path.Combine(txt_OutputDirectory.Text, txt_OutputFilename.Text) + "\" "
                         + (selectedMediaType != MediaType.Floppy

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -17,8 +17,8 @@ namespace DICUI
         // Private UI-related variables
         private List<Tuple<char, string, bool>> _drives { get; set; }
         private List<int> _driveSpeeds { get { return new List<int> { 1, 2, 3, 4, 6, 8, 12, 16, 20, 24, 32, 40, 44, 48, 52, 56, 72 }; } }
-        private List<Tuple<string, KnownSystem?>> _systems { get; set; }
-        private List<Tuple<string, MediaType?>> _mediaTypes { get; set; }
+        private List<KeyValuePair<string, KnownSystem?>> _systems { get; set; }
+        private List<KeyValuePair<string, MediaType?>> _mediaTypes { get; set; }
         private Process childProcess { get; set; }
 
         private OptionsWindow _optionsWindow;
@@ -138,15 +138,15 @@ namespace DICUI
         /// </summary>
         private void PopulateMediaTypeAccordingToChosenSystem()
         {
-            var currentSystem = cmb_SystemType.SelectedItem as Tuple<string, KnownSystem?>;
+            var currentSystem = cmb_SystemType.SelectedItem as KeyValuePair<string, KnownSystem?>?;
 
             if (currentSystem != null)
             {
-                _mediaTypes = Utilities.Validation.GetValidMediaTypes(currentSystem.Item2)
-                    .Select(i => new Tuple<string, MediaType?>(i.Key, i.Value))
+                _mediaTypes = Utilities.Validation.GetValidMediaTypes(currentSystem?.Value)
+                    .Select(i => new KeyValuePair<string, MediaType?>(i.Key, i.Value))
                     .ToList();
                 cmb_MediaType.ItemsSource = _mediaTypes;
-                cmb_MediaType.DisplayMemberPath = "Item1";
+                cmb_MediaType.DisplayMemberPath = "Key";
 
                 cmb_MediaType.IsEnabled = _mediaTypes.Count > 1;
                 cmb_MediaType.SelectedIndex = 0;
@@ -165,10 +165,10 @@ namespace DICUI
         private void PopulateSystems()
         {
             _systems = Utilities.Validation.CreateListOfSystems()
-                .Select(i => new Tuple<string, KnownSystem?>(i.Key, i.Value))
+                .Select(i => new KeyValuePair<string, KnownSystem?>(i.Key, i.Value))
                 .ToList();
             cmb_SystemType.ItemsSource = _systems;
-            cmb_SystemType.DisplayMemberPath = "Item1";
+            cmb_SystemType.DisplayMemberPath = "Key";
             cmb_SystemType.SelectedIndex = 0;
             cmb_SystemType_SelectionChanged(null, null);
 
@@ -233,7 +233,7 @@ namespace DICUI
             // Populate all tuples
             var driveLetterTuple = cmb_DriveLetter.SelectedItem as Tuple<char, string, bool>;
             var systemTypeTuple = cmb_SystemType.SelectedValue as KeyValuePair<string, KnownSystem?>?;
-            var MediaTypeTuple = cmb_MediaType.SelectedValue as KeyValuePair<string, MediaType?>?;
+            var mediaTypeTuple = cmb_MediaType.SelectedValue as KeyValuePair<string, MediaType?>?;
 
             // Get the currently selected options
             string dicPath = _options.dicPath;
@@ -245,7 +245,7 @@ namespace DICUI
             string outputFilename = txt_OutputFilename.Text;
             string systemName = systemTypeTuple?.Key;
             KnownSystem? system = systemTypeTuple?.Value;
-            MediaType? type = MediaTypeTuple?.Value;
+            MediaType? type = mediaTypeTuple?.Value;
 
             string customParameters = txt_Parameters.Text;
 
@@ -455,15 +455,15 @@ namespace DICUI
         /// </summary>
         private void EnsureDiscInformation()
         {
-            var systemTuple = cmb_SystemType.SelectedItem as Tuple<string, KnownSystem?>;
-            var MediaTypeTuple = cmb_MediaType.SelectedItem as Tuple<string, MediaType?>;
+            var systemTuple = cmb_SystemType.SelectedItem as KeyValuePair<string, KnownSystem?>?;
+            var mediaTypeTuple = cmb_MediaType.SelectedItem as KeyValuePair<string, MediaType?>?;
 
             // If we're on a separator, go to the next item
-            if (systemTuple.Item2 == null)
-                systemTuple = cmb_SystemType.Items[++cmb_SystemType.SelectedIndex] as Tuple<string, KnownSystem?>;
+            if (systemTuple?.Value == null)
+                systemTuple = cmb_SystemType.Items[++cmb_SystemType.SelectedIndex] as KeyValuePair<string, KnownSystem?>?;
 
-            var selectedSystem = systemTuple.Item2;
-            var selectedMediaType = MediaTypeTuple != null ? MediaTypeTuple.Item2 : MediaType.NONE;
+            var selectedSystem = systemTuple?.Value;
+            var selectedMediaType = mediaTypeTuple != null ? mediaTypeTuple?.Value : MediaType.NONE;
 
             // No system chosen, update status
             if (selectedSystem == KnownSystem.NONE)
@@ -482,7 +482,7 @@ namespace DICUI
                         break;
                     case MediaType.GameCubeGameDisc:
                     case MediaType.GDROM:
-                        lbl_Status.Content = string.Format("{0} discs are partially supported by DIC", MediaTypeTuple.Item1);
+                        lbl_Status.Content = string.Format("{0} discs are partially supported by DIC", mediaTypeTuple?.Key);
                         btn_StartStop.IsEnabled = (_drives.Count > 0 ? true : false);
                         break;
                     case MediaType.HDDVD:
@@ -493,23 +493,23 @@ namespace DICUI
                     case MediaType.WiiUOpticalDisc:
                     case MediaType.Cartridge:
                     case MediaType.Cassette:
-                        lbl_Status.Content = string.Format("{0} discs are not currently supported by DIC", MediaTypeTuple.Item1);
+                        lbl_Status.Content = string.Format("{0} discs are not currently supported by DIC", mediaTypeTuple?.Key);
                         btn_StartStop.IsEnabled = false;
                         break;
                     case MediaType.DVD:
                         if (selectedSystem == KnownSystem.MicrosoftXBOX360XDG3)
                         {
-                            lbl_Status.Content = string.Format("{0} discs are not currently supported by DIC", MediaTypeTuple.Item1);
+                            lbl_Status.Content = string.Format("{0} discs are not currently supported by DIC", mediaTypeTuple?.Key);
                             btn_StartStop.IsEnabled = false;
                         }
                         else
                         {
-                            lbl_Status.Content = string.Format("{0} ready to dump", MediaTypeTuple.Item1);
+                            lbl_Status.Content = string.Format("{0} ready to dump", mediaTypeTuple?.Key);
                             btn_StartStop.IsEnabled = (_drives.Count > 0 ? true : false);
                         }
                         break;
                     default:
-                        lbl_Status.Content = string.Format("{0} ready to dump", MediaTypeTuple.Item1);
+                        lbl_Status.Content = string.Format("{0} ready to dump", mediaTypeTuple?.Key);
                         btn_StartStop.IsEnabled = (_drives.Count > 0 ? true : false);
                         break;
                 }
@@ -587,13 +587,13 @@ namespace DICUI
         private void GetOutputNames()
         {
             var driveTuple = cmb_DriveLetter.SelectedItem as Tuple<char, string, bool>;
-            var systemTuple = cmb_SystemType.SelectedItem as Tuple<string, KnownSystem?>;
-            var discTuple = cmb_MediaType.SelectedItem as Tuple<string, MediaType?>;
+            var systemTuple = cmb_SystemType.SelectedItem as KeyValuePair<string, KnownSystem?>?;
+            var discTuple = cmb_MediaType.SelectedItem as KeyValuePair<string, MediaType?>?;
 
             if (driveTuple != null && systemTuple != null && discTuple != null)
             {
                 txt_OutputDirectory.Text = Path.Combine(_options.defaultOutputPath, driveTuple.Item2);
-                txt_OutputFilename.Text = driveTuple.Item2 + Converters.MediaTypeToExtension(discTuple.Item2);
+                txt_OutputFilename.Text = driveTuple.Item2 + Converters.MediaTypeToExtension(discTuple?.Value);
             }
             else
             {

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
@@ -17,7 +18,7 @@ namespace DICUI
         private List<Tuple<char, string, bool>> _drives { get; set; }
         private List<int> _driveSpeeds { get { return new List<int> { 1, 2, 3, 4, 6, 8, 12, 16, 20, 24, 32, 40, 44, 48, 52, 56, 72 }; } }
         private List<Tuple<string, KnownSystem?>> _systems { get; set; }
-        private List<Tuple<string, MediaType?>> _MediaTypes { get; set; }
+        private List<Tuple<string, MediaType?>> _mediaTypes { get; set; }
         private Process childProcess { get; set; }
 
         private OptionsWindow _optionsWindow;
@@ -141,11 +142,13 @@ namespace DICUI
 
             if (currentSystem != null)
             {
-                _MediaTypes = Utilities.Validation.GetValidMediaTypes(currentSystem.Item2);
-                cmb_MediaType.ItemsSource = _MediaTypes;
+                _mediaTypes = Utilities.Validation.GetValidMediaTypes(currentSystem.Item2)
+                    .Select(i => new Tuple<string, MediaType?>(i.Key, i.Value))
+                    .ToList();
+                cmb_MediaType.ItemsSource = _mediaTypes;
                 cmb_MediaType.DisplayMemberPath = "Item1";
 
-                cmb_MediaType.IsEnabled = _MediaTypes.Count > 1;
+                cmb_MediaType.IsEnabled = _mediaTypes.Count > 1;
                 cmb_MediaType.SelectedIndex = 0;
             }
             else
@@ -161,7 +164,9 @@ namespace DICUI
         /// </summary>
         private void PopulateSystems()
         {
-            _systems = Utilities.Validation.CreateListOfSystems();
+            _systems = Utilities.Validation.CreateListOfSystems()
+                .Select(i => new Tuple<string, KnownSystem?>(i.Key, i.Value))
+                .ToList();
             cmb_SystemType.ItemsSource = _systems;
             cmb_SystemType.DisplayMemberPath = "Item1";
             cmb_SystemType.SelectedIndex = 0;
@@ -227,8 +232,8 @@ namespace DICUI
 
             // Populate all tuples
             var driveLetterTuple = cmb_DriveLetter.SelectedItem as Tuple<char, string, bool>;
-            var systemTypeTuple = cmb_SystemType.SelectedValue as Tuple<string, KnownSystem?>;
-            var MediaTypeTuple = cmb_MediaType.SelectedValue as Tuple<string, MediaType?>;
+            var systemTypeTuple = cmb_SystemType.SelectedValue as KeyValuePair<string, KnownSystem?>?;
+            var MediaTypeTuple = cmb_MediaType.SelectedValue as KeyValuePair<string, MediaType?>?;
 
             // Get the currently selected options
             string dicPath = _options.dicPath;
@@ -238,9 +243,9 @@ namespace DICUI
             bool isFloppy = driveLetterTuple.Item3;
             string outputDirectory = txt_OutputDirectory.Text;
             string outputFilename = txt_OutputFilename.Text;
-            string systemName = systemTypeTuple.Item1;
-            KnownSystem? system = systemTypeTuple.Item2;
-            MediaType? type = MediaTypeTuple.Item2;
+            string systemName = systemTypeTuple?.Key;
+            KnownSystem? system = systemTypeTuple?.Value;
+            MediaType? type = MediaTypeTuple?.Value;
 
             string customParameters = txt_Parameters.Text;
 

--- a/Options.cs
+++ b/Options.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Configuration;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DICUI
 {

--- a/README.md
+++ b/README.md
@@ -1,111 +1,30 @@
 # DICUI
-Disc Image Creator UI in C#
+
+DiscImageCreator UI in C#
 
 This is a community project, so if you have some time and knowledge to give, we'll be glad to add you to the contributor of this project :)
 
-We are using Disc Image Creator, created by Sarami, and we would like to thanks him for his great software.
+We are using DiscImageCreator, created by Sarami, and we would like to thanks him for his great software. The latest release of DIC can be found on [the GitHub page](https://github.com/saramibreak/DiscImageCreator)
 
-You can get the latest code and released on his github right here:
-https://github.com/saramibreak/DiscImageCreator
---------------------------------------------------------------------------
-Currently working on the project:
- 
-ReignStumble - Co-Lead Programmer
-
-darksabre76 - Co-Lead Programmer
-
-Jakz - Contributer
-
-NHellFire - Contributer
-
-Dizzzy - Concept/Ideas/Beta tester
-
-## Changelist
+## Releases
 
 Download the latest release here:
 [https://github.com/reignstumble/DICUI/releases](https://github.com/reignstumble/DICUI/releases)
 
---------------------------------------------------------------------------
-2018-06-15
---------------------------------------------------------------------------
+## Changelist
 
-Version 1.06 released:
+A list of all changes can now be found [here](https://github.com/reignstumble/DICUI/blob/master/CHANGELIST.md).
 
-- Fixed not being able to use the `/c2` flag properly
-- Fixed times when the ability to start dumping was improperly allowed
-- Added full support for XBOX and XBOX360 (XDG1, XDG2) dumping through DIC (using a Kreon, or presumably a 0800)
+## Contributors
 
---------------------------------------------------------------------------
-2018-06-14
---------------------------------------------------------------------------
+Here are the talented people who have contributed to the project so far:
 
-Version 1.05a released:
+**ReignStumble** - Project Lead / UI Design
 
-- Fixed some ordering and nullability issues
-- Added automatic fields for PS1, PS2, Saturn
+**darksabre76** - Project Co-Lead / Backend Design
 
-Version 1.05 released:
+**Jakz** - Feature Contributor
 
-- Miscellaneous fixes around custom parameter validation, dump information accuracy, settings window, and TODO cleanup
-- Add many more supported platforms, mostly arcade (based on publicly available information)
-- Add floppy disk dumping support
-- Add optional disc eject on completion
-- Add subdump for Sega Saturn
-- Fully support newest version of DIC including all new flags and commands
+**NHellFire** - Feature Contributor
 
-**Known Issues:**
-
-- PlayStation and Saturn discs still don't have all internal information automatically generated
-
---------------------------------------------------------------------------
-2018-06-13
---------------------------------------------------------------------------
-
-Version 1.04b released:
-
-- Added subIntention reading
-- Fixed extra extensions being appended
-- Fixed internationalization error (number formatting)
-- Fixed "Custom Input" not working
-
-Version 1.04a released:
-
-- Fixed issue with empty trays
-- Added settings dialog
-
-Version 1.04 released:
-
-- Behind-the-scenes fixes and formatting
-- Better checks for external programs
-- Automatically changing disc information
-- Custom parameters (and parameter validation)
-- Automatic drive speed selection
-- Automatic submission information creation
-- Add ability to stop a dump from the UI
-
---------------------------------------------------------------------------
-2018-06-08
---------------------------------------------------------------------------
-
-Version 1.03 released:
-
-- edccchk now run on all CD-Roms
-- Discs unsupported by Windows are now regonized
-- Extra \ when accepting default save has been removed.
- 
---------------------------------------------------------------------------
-2018-05-18
---------------------------------------------------------------------------
-
-Version 1.02b released:
-
-- Fixed XBOX One and PS4 Drive Speed issue. (1.02)
-- Started implementing DiscImageCreator Path selection. (1.02)
-- Conforming my naming for objects and variable. (1.02)
-- Added missing DLL (1.02b)
-
---------------------------------------------------------------------------
-2018-05-14
---------------------------------------------------------------------------
-
-Version 1.01d released
+**Dizzzy** - Concept/Ideas/Beta tester

--- a/Utilities/Converters.cs
+++ b/Utilities/Converters.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using DICUI.External;
 
 namespace DICUI.Utilities
 {
@@ -199,8 +200,8 @@ namespace DICUI.Utilities
         public static List<string> KnownSystemAndMediaTypeToParameters(KnownSystem? sys, MediaType? type)
         {
             // First check to see if the combination of system and MediaType is valid
-            List<Tuple<string, MediaType?>> validTypes = Validation.GetValidMediaTypes(sys);
-            if (!validTypes.Select(i => i.Item2).Contains(type))
+            var validTypes = Validation.GetValidMediaTypes(sys);
+            if (!validTypes.ContainsKey(MediaTypeToString(type)))
             {
                 return null;
             }

--- a/Utilities/Converters.cs
+++ b/Utilities/Converters.cs
@@ -7,36 +7,36 @@ namespace DICUI.Utilities
     public static class Converters
     {
         /// <summary>
-        /// Get the DiscType associated with a given base command
+        /// Get the MediaType associated with a given base command
         /// </summary>
         /// <param name="baseCommand">String value to check</param>
-        /// <returns>DiscType if possible, null on error</returns>
+        /// <returns>MediaType if possible, null on error</returns>
         /// <remarks>This takes the "safe" route by assuming the larger of any given format</remarks>
-        public static DiscType? BaseCommmandToDiscType(string baseCommand)
+        public static MediaType? BaseCommmandToMediaType(string baseCommand)
         {
             switch (baseCommand)
             {
                 case DICCommands.CompactDisc:
-                    return DiscType.CD;
+                    return MediaType.CD;
                 case DICCommands.GDROM:
                 case DICCommands.Swap:
-                    return DiscType.GDROM;
+                    return MediaType.GDROM;
                 case DICCommands.DigitalVideoDisc:
                 case DICCommands.XBOX:
-                    return DiscType.DVD;
+                    return MediaType.DVD;
                 case DICCommands.BluRay:
-                    return DiscType.BluRay;
+                    return MediaType.BluRay;
 
                 // Non-optical
                 case DICCommands.Floppy:
-                    return DiscType.Floppy;
+                    return MediaType.Floppy;
                 default:
                     return null;
             }
         }
 
         /// <summary>
-        /// Get the most common known system for a given DiscType
+        /// Get the most common known system for a given MediaType
         /// </summary>
         /// <param name="baseCommand">String value to check</param>
         /// <returns>KnownSystem if possible, null on error</returns>
@@ -63,100 +63,100 @@ namespace DICUI.Utilities
         /// <summary>
         /// Get the default extension for a given disc type
         /// </summary>
-        /// <param name="type">DiscType value to check</param>
+        /// <param name="type">MediaType value to check</param>
         /// <returns>Valid extension (with leading '.'), null on error</returns>
-        public static string DiscTypeToExtension(DiscType? type)
+        public static string MediaTypeToExtension(MediaType? type)
         {
             switch (type)
             {
-                case DiscType.CD:
-                case DiscType.GDROM:
-                case DiscType.Cartridge:
+                case MediaType.CD:
+                case MediaType.GDROM:
+                case MediaType.Cartridge:
                     return ".bin";
-                case DiscType.DVD:
-                case DiscType.HDDVD:
-                case DiscType.BluRay:
-                case DiscType.WiiOpticalDisc:
-                case DiscType.UMD:
+                case MediaType.DVD:
+                case MediaType.HDDVD:
+                case MediaType.BluRay:
+                case MediaType.WiiOpticalDisc:
+                case MediaType.UMD:
                     return ".iso";
-                case DiscType.LaserDisc:
-                case DiscType.GameCubeGameDisc:
+                case MediaType.LaserDisc:
+                case MediaType.GameCubeGameDisc:
                     return ".raw";
-                case DiscType.WiiUOpticalDisc:
+                case MediaType.WiiUOpticalDisc:
                     return ".wud";
-                case DiscType.Floppy:
+                case MediaType.Floppy:
                     return ".img";
-                case DiscType.Cassette:
+                case MediaType.Cassette:
                     return ".wav";
-                case DiscType.NONE:
-                case DiscType.CED:
+                case MediaType.NONE:
+                case MediaType.CED:
                 default:
                     return null;
             }
         }
 
         /// <summary>
-        /// Get the string representation of the DiscType enum values
+        /// Get the string representation of the MediaType enum values
         /// </summary>
-        /// <param name="type">DiscType value to convert</param>
+        /// <param name="type">MediaType value to convert</param>
         /// <returns>String representing the value, if possible</returns>
-        public static string DiscTypeToString(DiscType? type)
+        public static string MediaTypeToString(MediaType? type)
         {
             switch (type)
             {
-                case DiscType.CD:
+                case MediaType.CD:
                     return "CD-ROM";
-                case DiscType.DVD:
+                case MediaType.DVD:
                     return "DVD";
-                case DiscType.GDROM:
+                case MediaType.GDROM:
                     return "GD-ROM";
-                case DiscType.HDDVD:
+                case MediaType.HDDVD:
                     return "HD-DVD";
-                case DiscType.BluRay:
+                case MediaType.BluRay:
                     return "BluRay";
-                case DiscType.LaserDisc:
+                case MediaType.LaserDisc:
                     return "LaserDisc";
 
-                case DiscType.CED:
+                case MediaType.CED:
                     return "CED";
-                case DiscType.GameCubeGameDisc:
+                case MediaType.GameCubeGameDisc:
                     return "GameCube Game";
-                case DiscType.WiiOpticalDisc:
+                case MediaType.WiiOpticalDisc:
                     return "Wii Optical";
-                case DiscType.WiiUOpticalDisc:
+                case MediaType.WiiUOpticalDisc:
                     return "Wii U Optical";
-                case DiscType.UMD:
+                case MediaType.UMD:
                     return "UMD";
 
-                case DiscType.Cartridge:
+                case MediaType.Cartridge:
                     return "Cartridge";
-                case DiscType.Cassette:
+                case MediaType.Cassette:
                     return "Cassette Tape";
-                case DiscType.Floppy:
+                case MediaType.Floppy:
                     return "Floppy Disk";
 
-                case DiscType.NONE:
+                case MediaType.NONE:
                 default:
                     return "Unknown";
             }
         }
 
         /// <summary>
-        /// Get the DIC command to be used for a given DiscType
+        /// Get the DIC command to be used for a given MediaType
         /// </summary>
-        /// <param name="type">DiscType value to check</param>
+        /// <param name="type">MediaType value to check</param>
         /// <returns>String containing the command, null on error</returns>
-        public static string KnownSystemAndDiscTypeToBaseCommand(KnownSystem? sys, DiscType? type)
+        public static string KnownSystemAndMediaTypeToBaseCommand(KnownSystem? sys, MediaType? type)
         {
             switch (type)
             {
-                case DiscType.CD:
+                case MediaType.CD:
                     if (sys == KnownSystem.MicrosoftXBOX)
                     {
                         return DICCommands.XBOX;
                     }
                     return DICCommands.CompactDisc;
-                case DiscType.DVD:
+                case MediaType.DVD:
                     if (sys == KnownSystem.MicrosoftXBOX
                         || sys == KnownSystem.MicrosoftXBOX360XDG2
                         || sys == KnownSystem.MicrosoftXBOX360XDG3)
@@ -164,25 +164,25 @@ namespace DICUI.Utilities
                         return DICCommands.XBOX;
                     }
                     return DICCommands.DigitalVideoDisc;
-                case DiscType.GDROM:
+                case MediaType.GDROM:
                     return DICCommands.GDROM;
-                case DiscType.HDDVD:
+                case MediaType.HDDVD:
                     return null;
-                case DiscType.BluRay:
+                case MediaType.BluRay:
                     return DICCommands.BluRay;
 
                 // Special Formats
-                case DiscType.GameCubeGameDisc:
+                case MediaType.GameCubeGameDisc:
                     return DICCommands.DigitalVideoDisc;
-                case DiscType.WiiOpticalDisc:
+                case MediaType.WiiOpticalDisc:
                     return null;
-                case DiscType.WiiUOpticalDisc:
+                case MediaType.WiiUOpticalDisc:
                     return null;
-                case DiscType.UMD:
+                case MediaType.UMD:
                     return null;
 
                 // Non-optical
-                case DiscType.Floppy:
+                case MediaType.Floppy:
                     return DICCommands.Floppy;
 
                 default:
@@ -194,12 +194,12 @@ namespace DICUI.Utilities
         /// Get list of default parameters for a given system and disc type
         /// </summary>
         /// <param name="sys">KnownSystem value to check</param>
-        /// <param name="type">DiscType value to check</param>
+        /// <param name="type">MediaType value to check</param>
         /// <returns>List of strings representing the parameters</returns>
-        public static List<string> KnownSystemAndDiscTypeToParameters(KnownSystem? sys, DiscType? type)
+        public static List<string> KnownSystemAndMediaTypeToParameters(KnownSystem? sys, MediaType? type)
         {
-            // First check to see if the combination of system and disctype is valid
-            List<Tuple<string, DiscType?>> validTypes = Validation.GetValidDiscTypes(sys);
+            // First check to see if the combination of system and MediaType is valid
+            List<Tuple<string, MediaType?>> validTypes = Validation.GetValidMediaTypes(sys);
             if (!validTypes.Select(i => i.Item2).Contains(type))
             {
                 return null;
@@ -209,7 +209,7 @@ namespace DICUI.Utilities
             List<string> parameters = new List<string>();
             switch (type)
             {
-                case DiscType.CD:
+                case MediaType.CD:
                     parameters.Add(DICFlags.C2Opcode); parameters.Add("20");
 
                     switch (sys)
@@ -228,33 +228,33 @@ namespace DICUI.Utilities
                             break;
                     }
                     break;
-                case DiscType.DVD:
+                case MediaType.DVD:
                     // Currently no defaults set
                     break;
-                case DiscType.GDROM:
+                case MediaType.GDROM:
                     parameters.Add(DICFlags.C2Opcode); parameters.Add("20");
                     break;
-                case DiscType.HDDVD:
+                case MediaType.HDDVD:
                     break;
-                case DiscType.BluRay:
+                case MediaType.BluRay:
                     // Currently no defaults set
                     break;
 
                 // Special Formats
-                case DiscType.GameCubeGameDisc:
+                case MediaType.GameCubeGameDisc:
                     parameters.Add(DICFlags.Raw);
                     break;
-                case DiscType.WiiOpticalDisc:
+                case MediaType.WiiOpticalDisc:
                     // Currently no defaults set
                     break;
-                case DiscType.WiiUOpticalDisc:
+                case MediaType.WiiUOpticalDisc:
                     // Currently no defaults set
                     break;
-                case DiscType.UMD:
+                case MediaType.UMD:
                     break;
 
                 // Non-optical
-                case DiscType.Floppy:
+                case MediaType.Floppy:
                     // Currently no defaults set
                     break;
             }

--- a/Utilities/DumpInformation.cs
+++ b/Utilities/DumpInformation.cs
@@ -52,9 +52,9 @@ namespace DICUI.Utilities
         /// </summary>
         /// <param name="outputDirectory">Base directory to use</param>
         /// <param name="outputFilename">Base filename to use</param>
-        /// <param name="type">DiscType value to check</param>
+        /// <param name="type">MediaType value to check</param>
         /// <returns></returns>
-        public static bool FoundAllFiles(string outputDirectory, string outputFilename, DiscType? type)
+        public static bool FoundAllFiles(string outputDirectory, string outputFilename, MediaType? type)
         {
             // First, sanitized the output filename to strip off any potential extension
             outputFilename = Path.GetFileNameWithoutExtension(outputFilename);
@@ -63,8 +63,8 @@ namespace DICUI.Utilities
             string combinedBase = Path.Combine(outputDirectory, outputFilename);
             switch (type)
             {
-                case DiscType.CD:
-                case DiscType.GDROM: // TODO: Verify GD-ROM outputs this
+                case MediaType.CD:
+                case MediaType.GDROM: // TODO: Verify GD-ROM outputs this
                     return File.Exists(combinedBase + ".c2")
                         && File.Exists(combinedBase + ".ccd")
                         && File.Exists(combinedBase + ".cue")
@@ -85,13 +85,13 @@ namespace DICUI.Utilities
                         && File.Exists(combinedBase + "_subIntention.txt")
                         && File.Exists(combinedBase + "_subReadable.txt")
                         && File.Exists(combinedBase + "_volDesc.txt");
-                case DiscType.DVD:
-                case DiscType.HDDVD:
-                case DiscType.BluRay:
-                case DiscType.GameCubeGameDisc:
-                case DiscType.WiiOpticalDisc:
-                case DiscType.WiiUOpticalDisc:
-                case DiscType.UMD:
+                case MediaType.DVD:
+                case MediaType.HDDVD:
+                case MediaType.BluRay:
+                case MediaType.GameCubeGameDisc:
+                case MediaType.WiiOpticalDisc:
+                case MediaType.WiiUOpticalDisc:
+                case MediaType.UMD:
                     return File.Exists(combinedBase + ".dat")
                         && File.Exists(combinedBase + "_cmd.txt")
                         && File.Exists(combinedBase + "_disc.txt")
@@ -99,7 +99,7 @@ namespace DICUI.Utilities
                         && File.Exists(combinedBase + "_mainError.txt")
                         && File.Exists(combinedBase + "_mainInfo.txt")
                         && File.Exists(combinedBase + "_volDesc.txt");
-                case DiscType.Floppy:
+                case MediaType.Floppy:
                     return File.Exists(combinedBase + ".dat")
                         && File.Exists(combinedBase + "_cmd.txt")
                        && File.Exists(combinedBase + "_disc.txt");
@@ -115,11 +115,11 @@ namespace DICUI.Utilities
         /// <param name="outputDirectory">Base directory to use</param>
         /// <param name="outputFilename">Base filename to use</param>
         /// <param name="sys">KnownSystem value to check</param>
-        /// <param name="type">DiscType value to check</param>
+        /// <param name="type">MediaType value to check</param>
         /// <param name="driveLetter">Drive letter to check</param>
         /// <returns>Dictionary containing mapped output values, null on error</returns>
         /// <remarks>TODO: Make sure that all special formats are accounted for</remarks>
-        public static Dictionary<string, string> ExtractOutputInformation(string outputDirectory, string outputFilename, KnownSystem? sys, DiscType? type, char driveLetter)
+        public static Dictionary<string, string> ExtractOutputInformation(string outputDirectory, string outputFilename, KnownSystem? sys, MediaType? type, char driveLetter)
         {
             // First, sanitized the output filename to strip off any potential extension
             outputFilename = Path.GetFileNameWithoutExtension(outputFilename);
@@ -138,7 +138,7 @@ namespace DICUI.Utilities
                 { Template.DiscNumberField, Template.OptionalValue },
                 { Template.DiscTitleField, Template.OptionalValue },
                 { Template.SystemField, Converters.KnownSystemToString(sys) },
-                { Template.MediaTypeField, Converters.DiscTypeToString(type) },
+                { Template.MediaTypeField, Converters.MediaTypeToString(type) },
                 { Template.CategoryField, "Games" },
                 { Template.RegionField, "World (CHANGE THIS)" },
                 { Template.LanguagesField, "Klingon (CHANGE THIS)" },
@@ -151,11 +151,11 @@ namespace DICUI.Utilities
                 { Template.DATField, GetDatfile(combinedBase + ".dat") },
             };
 
-            // Now we want to do a check by DiscType and extract all required info
+            // Now we want to do a check by MediaType and extract all required info
             switch (type)
             {
-                case DiscType.CD:
-                case DiscType.GDROM: // TODO: Verify GD-ROM outputs this
+                case MediaType.CD:
+                case MediaType.GDROM: // TODO: Verify GD-ROM outputs this
                     mappings[Template.MasteringRingField] = Template.RequiredIfExistsValue;
                     mappings[Template.MasteringSIDField] = Template.RequiredIfExistsValue;
                     mappings[Template.MouldSIDField] = Template.RequiredIfExistsValue;
@@ -206,9 +206,9 @@ namespace DICUI.Utilities
                     }
 
                     break;
-                case DiscType.DVD:
-                case DiscType.HDDVD:
-                case DiscType.BluRay:
+                case MediaType.DVD:
+                case MediaType.HDDVD:
+                case MediaType.BluRay:
                     string layerbreak = GetLayerbreak(combinedBase + "_disc.txt");
                     
                     // If we have a single-layer disc
@@ -216,10 +216,10 @@ namespace DICUI.Utilities
                     {
                         switch (type)
                         {
-                            case DiscType.DVD:
+                            case MediaType.DVD:
                                 mappings[Template.MediaTypeField] += "-5";
                                 break;
-                            case DiscType.BluRay:
+                            case MediaType.BluRay:
                                 mappings[Template.MediaTypeField] += "-25";
                                 break;
                         }
@@ -235,10 +235,10 @@ namespace DICUI.Utilities
                     {
                         switch (type)
                         {
-                            case DiscType.DVD:
+                            case MediaType.DVD:
                                 mappings[Template.MediaTypeField] += "-9";
                                 break;
-                            case DiscType.BluRay:
+                            case MediaType.BluRay:
                                 mappings[Template.MediaTypeField] += "-50";
                                 break;
                         }
@@ -772,10 +772,10 @@ namespace DICUI.Utilities
         /// </summary>
         /// <param name="info">Information dictionary that should contain normalized values</param>
         /// <param name="sys">KnownSystem value to check</param>
-        /// <param name="type">DiscType value to check</param>
+        /// <param name="type">MediaType value to check</param>
         /// <returns>List of strings representing each line of an output file, null on error</returns>
         /// <remarks>TODO: Get full list of customizable stuff for other systems</remarks>
-        public static List<string> FormatOutputData(Dictionary<string, string> info, KnownSystem? sys, DiscType? type)
+        public static List<string> FormatOutputData(Dictionary<string, string> info, KnownSystem? sys, MediaType? type)
         {
             // Check to see if the inputs are valid
             if (info == null)
@@ -809,11 +809,11 @@ namespace DICUI.Utilities
                 output.Add("Ringcode Information:");
                 switch (type)
                 {
-                    case DiscType.CD:
-                    case DiscType.GDROM:
-                    case DiscType.DVD:
-                    case DiscType.HDDVD:
-                    case DiscType.BluRay:
+                    case MediaType.CD:
+                    case MediaType.GDROM:
+                    case MediaType.DVD:
+                    case MediaType.HDDVD:
+                    case MediaType.BluRay:
                         // If we have a dual-layer disc
                         if (info.ContainsKey(Template.LayerbreakField))
                         {
@@ -847,8 +847,8 @@ namespace DICUI.Utilities
                 }
                 switch (type)
                 {
-                    case DiscType.CD:
-                    case DiscType.GDROM:
+                    case MediaType.CD:
+                    case MediaType.GDROM:
                         output.Add(Template.ErrorCountField + ": " + info[Template.ErrorCountField]);
                         break;
                 }
@@ -870,8 +870,8 @@ namespace DICUI.Utilities
                 }
                 switch (type)
                 {
-                    case DiscType.DVD:
-                    case DiscType.BluRay:
+                    case MediaType.DVD:
+                    case MediaType.BluRay:
                         // If we have a dual-layer disc
                         if (info.ContainsKey(Template.LayerbreakField))
                         {
@@ -905,8 +905,8 @@ namespace DICUI.Utilities
                 }
                 switch (type)
                 {
-                    case DiscType.CD:
-                    case DiscType.GDROM:
+                    case MediaType.CD:
+                    case MediaType.GDROM:
                         output.Add(Template.CuesheetField + ":"); output.Add("");
                         output.AddRange(info[Template.CuesheetField].Split('\n')); output.Add("");
                         output.Add(Template.WriteOffsetField + ": " + info[Template.WriteOffsetField]); output.Add("");

--- a/Utilities/Validation.cs
+++ b/Utilities/Validation.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Management;
 using System.Text.RegularExpressions;
+using DICUI.External;
 
 namespace DICUI.Utilities
 {
@@ -15,14 +16,12 @@ namespace DICUI.Utilities
         /// <param name="sys">KnownSystem value to check</param>
         /// <returns>MediaTypes matched to enums, if possible</returns>
         /// <remarks>
-        /// This returns a List of Tuples whose structure is as follows:
-        ///		Item 1: Printable name
-        ///		Item 2: MediaType mapping
         ///	If something has a "string, null" value, it should be assumed that it is a separator
         /// </remarks>
-        public static List<Tuple<string, MediaType?>> GetValidMediaTypes(KnownSystem? sys)
+        public static OrderedDictionary<string, MediaType?> GetValidMediaTypes(KnownSystem? sys)
         {
-            List<MediaType?> types = new List<MediaType?>();
+            var types = new List<MediaType?>();
+            var typesDict = new OrderedDictionary<string, MediaType?>();
 
             switch (sys)
             {
@@ -370,7 +369,13 @@ namespace DICUI.Utilities
                     break;
             }
 
-            return types.Select(i => new Tuple<string, MediaType?>(Converters.MediaTypeToString(i), i)).ToList();
+            // Populate the dictionary
+            foreach (var type in types)
+            {
+                typesDict.Add(Converters.MediaTypeToString(type), type);
+            }
+
+            return typesDict;
         }
 
         /// <summary>
@@ -378,15 +383,12 @@ namespace DICUI.Utilities
         /// </summary>
         /// <returns>Systems matched to enums, if possible</returns>
         /// <remarks>
-        /// This returns a List of Tuples whose structure is as follows:
-        ///		Item 1: Printable name
-        ///		Item 2: KnownSystem mapping
         ///	If something has a "string, null" value, it should be assumed that it is a separator
         /// </remarks>
         /// TODO: Figure out a way that the sections can be generated more automatically
-        public static List<Tuple<string, KnownSystem?>> CreateListOfSystems()
+        public static OrderedDictionary<string, KnownSystem?> CreateListOfSystems()
         {
-            List<Tuple<string, KnownSystem?>> mapping = new List<Tuple<string, KnownSystem?>>();
+            var systemsDict = new OrderedDictionary<string, KnownSystem?>();
 
             foreach (KnownSystem system in Enum.GetValues(typeof(KnownSystem)))
             {
@@ -395,29 +397,29 @@ namespace DICUI.Utilities
                 {
                     // Consoles section
                     case KnownSystem.BandaiPlaydiaQuickInteractiveSystem:
-                        mapping.Add(new Tuple<string, KnownSystem?>("---------- Consoles ----------", null));
+                        systemsDict.Add("---------- Consoles ----------", null);
                         break;
 
                     // Computers section
                     case KnownSystem.AcornArchimedes:
-                        mapping.Add(new Tuple<string, KnownSystem?>("---------- Computers ----------", null));
+                        systemsDict.Add("---------- Computers ----------", null);
                         break;
 
                     // Arcade section
                     case KnownSystem.AmigaCUBOCD32:
-                        mapping.Add(new Tuple<string, KnownSystem?>("---------- Arcade ----------", null));
+                        systemsDict.Add("---------- Arcade ----------", null);
                         break;
 
                     // Other section
                     case KnownSystem.AudioCD:
-                        mapping.Add(new Tuple<string, KnownSystem?>("---------- Others ----------", null));
+                        systemsDict.Add("---------- Others ----------", null);
                         break;
                 }
 
-                mapping.Add(new Tuple<string, KnownSystem?>(Converters.KnownSystemToString(system), system));
+                systemsDict.Add(Converters.KnownSystemToString(system), system);
             }
 
-            return mapping;
+            return systemsDict;
         }
 
         /// <summary>

--- a/Utilities/Validation.cs
+++ b/Utilities/Validation.cs
@@ -10,112 +10,112 @@ namespace DICUI.Utilities
     public static class Validation
     {
         /// <summary>
-        /// Get a list of valid DiscTypes for a given system matched to their respective names
+        /// Get a list of valid MediaTypes for a given system matched to their respective names
         /// </summary>
         /// <param name="sys">KnownSystem value to check</param>
-        /// <returns>DiscTypes matched to enums, if possible</returns>
+        /// <returns>MediaTypes matched to enums, if possible</returns>
         /// <remarks>
         /// This returns a List of Tuples whose structure is as follows:
         ///		Item 1: Printable name
-        ///		Item 2: DiscType mapping
+        ///		Item 2: MediaType mapping
         ///	If something has a "string, null" value, it should be assumed that it is a separator
         /// </remarks>
-        public static List<Tuple<string, DiscType?>> GetValidDiscTypes(KnownSystem? sys)
+        public static List<Tuple<string, MediaType?>> GetValidMediaTypes(KnownSystem? sys)
         {
-            List<DiscType?> types = new List<DiscType?>();
+            List<MediaType?> types = new List<MediaType?>();
 
             switch (sys)
             {
                 #region Consoles
 
                 case KnownSystem.BandaiPlaydiaQuickInteractiveSystem:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.BandaiApplePippin:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.CommodoreAmigaCD32:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.CommodoreAmigaCDTV:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.MattelHyperscan:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.MicrosoftXBOX:
-                    types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.CD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.MicrosoftXBOX360XDG2:
-                    types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.CD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.MicrosoftXBOX360XDG3:
-                    types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD);
-                    types.Add(DiscType.HDDVD);
+                    types.Add(MediaType.CD);
+                    types.Add(MediaType.DVD);
+                    types.Add(MediaType.HDDVD);
                     break;
                 case KnownSystem.MicrosoftXBOXOne:
-                    types.Add(DiscType.BluRay);
+                    types.Add(MediaType.BluRay);
                     break;
                 case KnownSystem.NECPCEngineTurboGrafxCD:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.NECPCFX:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.NintendoGameCube:
-                    types.Add(DiscType.GameCubeGameDisc);
+                    types.Add(MediaType.GameCubeGameDisc);
                     break;
                 case KnownSystem.NintendoWii:
-                    types.Add(DiscType.WiiOpticalDisc);
+                    types.Add(MediaType.WiiOpticalDisc);
                     break;
                 case KnownSystem.NintendoWiiU:
-                    types.Add(DiscType.WiiUOpticalDisc);
+                    types.Add(MediaType.WiiUOpticalDisc);
                     break;
                 case KnownSystem.Panasonic3DOInteractiveMultiplayer:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.PhilipsCDi:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.SegaCDMegaCD:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.SegaDreamcast:
-                    types.Add(DiscType.GDROM);
+                    types.Add(MediaType.GDROM);
                     break;
                 case KnownSystem.SegaSaturn:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.SNKNeoGeoCD:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.SonyPlayStation:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.SonyPlayStation2:
-                    types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.CD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.SonyPlayStation3:
-                    types.Add(DiscType.BluRay);
+                    types.Add(MediaType.BluRay);
                     break;
                 case KnownSystem.SonyPlayStation4:
-                    types.Add(DiscType.BluRay);
+                    types.Add(MediaType.BluRay);
                     break;
                 case KnownSystem.SonyPlayStationPortable:
-                    types.Add(DiscType.UMD);
+                    types.Add(MediaType.UMD);
                     break;
                 case KnownSystem.VMLabsNuon:
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.VTechVFlashVSmilePro:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.ZAPiTGamesGameWaveFamilyEntertainmentSystem:
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.DVD);
                     break;
 
                 #endregion
@@ -123,32 +123,32 @@ namespace DICUI.Utilities
                 #region Computers
 
                 case KnownSystem.AcornArchimedes:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.AppleMacintosh:
-                    types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD);
-                    types.Add(DiscType.Floppy);
+                    types.Add(MediaType.CD);
+                    types.Add(MediaType.DVD);
+                    types.Add(MediaType.Floppy);
                     break;
                 case KnownSystem.CommodoreAmigaCD:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.FujitsuFMTowns:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.IBMPCCompatible:
-                    types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD);
-                    types.Add(DiscType.Floppy);
+                    types.Add(MediaType.CD);
+                    types.Add(MediaType.DVD);
+                    types.Add(MediaType.Floppy);
                     break;
                 case KnownSystem.NECPC88:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.NECPC98:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.SharpX68000:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
 
                 #endregion
@@ -156,169 +156,169 @@ namespace DICUI.Utilities
                 #region Arcade
 
                 case KnownSystem.AmigaCUBOCD32:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.AmericanLaserGames3DO:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.Atari3DO:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.Atronic:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.AUSCOMSystem1:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.BallyGameMagic:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.CapcomCPSystemIII:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.GlobalVRVarious:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.GlobalVRVortek:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.GlobalVRVortekV3:
-                    types.Add(DiscType.DVD); // TODO: Confirm
+                    types.Add(MediaType.DVD); // TODO: Confirm
                     break;
                 case KnownSystem.ICEPCHardware:
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.IncredibleTechnologiesEagle:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.IncredibleTechnologiesVarious:
-                    types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.CD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.KonamiFirebeat:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.KonamiGVSystem:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.KonamiM2:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.KonamiPython:
-                    types.Add(DiscType.DVD); // TODO: Confirm
+                    types.Add(MediaType.DVD); // TODO: Confirm
                     break;
                 case KnownSystem.KonamiPython2:
-                    types.Add(DiscType.DVD); // TODO: Confirm
+                    types.Add(MediaType.DVD); // TODO: Confirm
                     break;
                 case KnownSystem.KonamiSystem573:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.KonamiTwinkle:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.KonamiVarious:
-                    types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.CD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.MeritIndustriesBoardwalk:
-                    types.Add(DiscType.CD); // TODO: Confirm
+                    types.Add(MediaType.CD); // TODO: Confirm
                     break;
                 case KnownSystem.MeritIndustriesMegaTouchAurora:
-                    types.Add(DiscType.CD); // TODO: Confirm
+                    types.Add(MediaType.CD); // TODO: Confirm
                     break;
                 case KnownSystem.MeritIndustriesMegaTouchForce:
-                    types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.CD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.MeritIndustriesMegaTouchION:
-                    types.Add(DiscType.CD);
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.CD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.MeritIndustriesMegaTouchMaxx:
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.MeritIndustriesMegaTouchXL:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.NamcoCapcomSystem256:
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.NamcoCapcomTaitoSystem246:
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.NamcoSegaNintendoTriforce:
-                    types.Add(DiscType.GDROM);
+                    types.Add(MediaType.GDROM);
                     break;
                 case KnownSystem.NamcoSystem12:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.NamcoSystem357:
-                    types.Add(DiscType.DVD);
-                    types.Add(DiscType.BluRay);
+                    types.Add(MediaType.DVD);
+                    types.Add(MediaType.BluRay);
                     break;
                 case KnownSystem.NewJatreCDi:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.NichibutsuHighRateSystem:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.NichibutsuSuperCD:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.NichibutsuXRateSystem:
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.PhotoPlayVarious:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.RawThrillsVarious:
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.SegaChihiro:
-                    types.Add(DiscType.GDROM);
+                    types.Add(MediaType.GDROM);
                     break;
                 case KnownSystem.SegaEuropaR:
-                    types.Add(DiscType.DVD); // TODO: Confirm
+                    types.Add(MediaType.DVD); // TODO: Confirm
                     break;
                 case KnownSystem.SegaLindbergh:
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.SegaNaomi:
-                    types.Add(DiscType.GDROM);
+                    types.Add(MediaType.GDROM);
                     break;
                 case KnownSystem.SegaNaomi2:
-                    types.Add(DiscType.GDROM);
+                    types.Add(MediaType.GDROM);
                     break;
                 case KnownSystem.SegaNu:
-                    types.Add(DiscType.DVD);
-                    types.Add(DiscType.BluRay);
+                    types.Add(MediaType.DVD);
+                    types.Add(MediaType.BluRay);
                     break;
                 case KnownSystem.SegaRingEdge:
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.SegaRingEdge2:
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.SegaRingWide:
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.SegaSTV:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.SegaSystem32:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.SeibuCATSSystem:
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.TABAustriaQuizard:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.TandyMemorexVisualInformationSystem:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.TsunamiTsuMoMultiGameMotionSystem:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
 
                 #endregion
@@ -326,51 +326,51 @@ namespace DICUI.Utilities
                 #region Others
 
                 case KnownSystem.AudioCD:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.BDVideo:
-                    types.Add(DiscType.BluRay);
+                    types.Add(MediaType.BluRay);
                     break;
                 case KnownSystem.DVDVideo:
-                    types.Add(DiscType.DVD);
+                    types.Add(MediaType.DVD);
                     break;
                 case KnownSystem.EnhancedCD:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.HDDVDVideo:
-                    types.Add(DiscType.HDDVD);
+                    types.Add(MediaType.HDDVD);
                     break;
                 case KnownSystem.PalmOS:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.PhilipsCDiDigitalVideo:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.PhotoCD:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.PlayStationGameSharkUpdates:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.TaoiKTV:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.TomyKissSite:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
                 case KnownSystem.VideoCD:
-                    types.Add(DiscType.CD);
+                    types.Add(MediaType.CD);
                     break;
 
                 #endregion
 
                 case KnownSystem.NONE:
                 default:
-                    types.Add(DiscType.NONE);
+                    types.Add(MediaType.NONE);
                     break;
             }
 
-            return types.Select(i => new Tuple<string, DiscType?>(Converters.DiscTypeToString(i), i)).ToList();
+            return types.Select(i => new Tuple<string, MediaType?>(Converters.MediaTypeToString(i), i)).ToList();
         }
 
         /// <summary>
@@ -1011,12 +1011,12 @@ namespace DICUI.Utilities
         /// Determine the base flags to use for checking a commandline
         /// </summary>
         /// <param name="parameters">Parameters as a string to check</param>
-        /// <param name="type">Output nullable DiscType containing the found DiscType, if possible</param>
+        /// <param name="type">Output nullable MediaType containing the found MediaType, if possible</param>
         /// <param name="system">Output nullable KnownSystem containing the found KnownSystem, if possible</param>
         /// <param name="letter">Output string containing the found drive letter</param>
         /// <param name="path">Output string containing the found path</param>
         /// <returns>False on error (and all outputs set to null), true otherwise</returns>
-        public static bool DetermineFlags(string parameters, out DiscType? type, out KnownSystem? system, out string letter, out string path)
+        public static bool DetermineFlags(string parameters, out MediaType? type, out KnownSystem? system, out string letter, out string path)
         {
             // Populate all output variables with null
             type = null; system = null; letter = null; path = null;
@@ -1035,7 +1035,7 @@ namespace DICUI.Utilities
                 .Select(m => m.Value)
                 .ToList();
 
-            type = Converters.BaseCommmandToDiscType(parts[0]);
+            type = Converters.BaseCommmandToMediaType(parts[0]);
             system = Converters.BaseCommandToKnownSystem(parts[0]);
 
             // Determine what the commandline should look like given the first item
@@ -1065,20 +1065,20 @@ namespace DICUI.Utilities
                     // Special case for GameCube/Wii
                     if (parts.Contains(DICFlags.Raw))
                     {
-                        type = DiscType.GameCubeGameDisc;
+                        type = MediaType.GameCubeGameDisc;
                         system = KnownSystem.NintendoGameCube;
                     }
                     // Special case for PlayStation
                     else if (parts.Contains(DICFlags.NoFixSubQLibCrypt)
                         || parts.Contains(DICFlags.ScanAntiMod))
                     {
-                        type = DiscType.CD;
+                        type = MediaType.CD;
                         system = KnownSystem.SonyPlayStation;
                     }
                     // Special case for Saturn
                     else if (parts.Contains(DICFlags.SeventyFour))
                     {
-                        type = DiscType.CD;
+                        type = MediaType.CD;
                         system = KnownSystem.SegaSaturn;
                     }
 


### PR DESCRIPTION
- Renamed `DiscType` to `MediaType` to better reflect the enum values (fixes #67)
- Created CHANGELIST.md for a better, centralized experience (edited README.md in the process) (fixes #68)
- Remove as many usages of tuple as possible for the time being (fixes #66)
    - Added the `OrderedDictionary<TKey, TValue>` type for future use. This is a generic version of the `System.Collections.Specialized.OrderedDictionary` type
- Add string replacement for both `.` and `&` until a better solution can be found (fixes #54) (fixes #59)
    - As of now, both characters are replaced by `_`. This can be changed in the future.
