### PR TITLE
Remove Redundant Calls and PSX Automation

### DIFF
--- a/App.config
+++ b/App.config
@@ -2,7 +2,6 @@
 <configuration>
   <appSettings>
     <add key="dicPath" value="Programs\DiscImageCreator.exe"/>
-    <add key="psxt001zPath" value="psxt001z.exe"/>
     <add key="subdumpPath" value="subdump.exe"/>
     <add key="defaultOutputPath" value="ISO"/>
   </appSettings>

--- a/Data/Constants.cs
+++ b/Data/Constants.cs
@@ -103,7 +103,7 @@
         public const string LayerbreakField = "Layerbreak";
         public const string PlaystationEXEDateField = "EXE Date";
         public const string PlayStationEDCField = "EDC";
-        public const string PlayStationAntiModchipField = "Anti-modchip"; // TODO: Not automatic yet
+        public const string PlayStationAntiModchipField = "Anti-modchip";
         public const string PlayStationLibCryptField = "LibCrypt"; // TODO: Not automatic yet
         public const string SaturnHeaderField = "Header";
         public const string SaturnBuildDateField = "Build Date";

--- a/Data/Constants.cs
+++ b/Data/Constants.cs
@@ -102,7 +102,7 @@
         public const string WriteOffsetField = "Write Offset";
         public const string LayerbreakField = "Layerbreak";
         public const string PlaystationEXEDateField = "EXE Date";
-        public const string PlayStationEDCField = "EDC"; // TODO: Not automatic yet
+        public const string PlayStationEDCField = "EDC";
         public const string PlayStationAntiModchipField = "Anti-modchip"; // TODO: Not automatic yet
         public const string PlayStationLibCryptField = "LibCrypt"; // TODO: Not automatic yet
         public const string SaturnHeaderField = "Header";

--- a/Data/Constants.cs
+++ b/Data/Constants.cs
@@ -98,7 +98,7 @@
         public const string DATField = "DAT";
         public const string ErrorCountField = "Error Count";
         public const string CuesheetField = "Cuesheet";
-        public const string SubIntentionField = "SubIntention Data (SecuROM)";
+        public const string SubIntentionField = "SubIntention Data (SecuROM/LibCrypt)";
         public const string WriteOffsetField = "Write Offset";
         public const string LayerbreakField = "Layerbreak";
         public const string PlaystationEXEDateField = "EXE Date";

--- a/Data/Constants.cs
+++ b/Data/Constants.cs
@@ -104,7 +104,7 @@
         public const string PlaystationEXEDateField = "EXE Date";
         public const string PlayStationEDCField = "EDC";
         public const string PlayStationAntiModchipField = "Anti-modchip";
-        public const string PlayStationLibCryptField = "LibCrypt"; // TODO: Not automatic yet
+        public const string PlayStationLibCryptField = "LibCrypt";
         public const string SaturnHeaderField = "Header";
         public const string SaturnBuildDateField = "Build Date";
         public const string XBOXDMIHash = "DMI.bin Hashes";

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -597,6 +597,9 @@ namespace DICUI
         /// </summary>
         private void SetSupportedDriveSpeed()
         {
+            // Set generic drive speed just in case
+            cmb_DriveSpeed.SelectedItem = 8;
+
             // Get the drive letter from the selected item
             var selected = cmb_DriveLetter.SelectedItem as KeyValuePair<char, string>?;
             if (selected == null || (selected?.Value == UIElements.FloppyDriveString))

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -245,7 +245,6 @@ namespace DICUI
 
             // Get the currently selected options
             string dicPath = _options.dicPath;
-            string psxtPath = _options.psxtPath;
             string subdumpPath = _options.subdumpPath;
             char driveLetter = (char)driveKvp?.Key;
             bool isFloppy = (driveKvp?.Value == UIElements.FloppyDriveString);
@@ -336,51 +335,6 @@ namespace DICUI
                             {
                                 FileName = subdumpPath,
                                 Arguments = "-i " + driveLetter + ": -f " + Path.Combine(outputDirectory, Path.GetFileNameWithoutExtension(outputFilename) + "_subdump.sub") + "-mode 6 -rereadnum 25 -fix 2",
-                            },
-                        };
-                        childProcess.Start();
-                        childProcess.WaitForExit();
-                    });
-                    break;
-                case KnownSystem.SonyPlayStation:
-                    if (!File.Exists(psxtPath))
-                    {
-                        lbl_Status.Content = "Error! Could not find psxt001z!";
-                        break;
-                    }
-
-                    // Invoke the program with all 3 configurations
-                    // TODO: Use these outputs for PSX information
-                    await Task.Run(() =>
-                    {
-                        childProcess = new Process()
-                        {
-                            StartInfo = new ProcessStartInfo()
-                            {
-                                FileName = psxtPath,
-                                Arguments = "\"" + DumpInformation.GetFirstTrack(outputDirectory, outputFilename) + "\" > " + "\"" + Path.Combine(outputDirectory, "psxt001z.txt"),
-                            },
-                        };
-                        childProcess.Start();
-                        childProcess.WaitForExit();
-
-                        childProcess = new Process()
-                        {
-                            StartInfo = new ProcessStartInfo()
-                            {
-                                FileName = psxtPath,
-                                Arguments = "--libcrypt \"" + Path.Combine(outputDirectory, Path.GetFileNameWithoutExtension(outputFilename) + ".sub") + "\" > \"" + Path.Combine(outputDirectory, "libcrypt.txt"),
-                            },
-                        };
-                        childProcess.Start();
-                        childProcess.WaitForExit();
-
-                        childProcess = new Process()
-                        {
-                            StartInfo = new ProcessStartInfo()
-                            {
-                                FileName = psxtPath,
-                                Arguments = "--libcryptdrvfast " + driveLetter + " > " + "\"" + Path.Combine(outputDirectory, "libcryptdrv.log"),
                             },
                         };
                         childProcess.Start();

--- a/Options.cs
+++ b/Options.cs
@@ -8,7 +8,6 @@ namespace DICUI
     {
         public string defaultOutputPath { get; private set; }
         public string dicPath { get; private set; }
-        public string psxtPath { get; private set; }
         public string subdumpPath { get; private set; }
 
         public void Save()
@@ -31,7 +30,6 @@ namespace DICUI
         {
             //TODO: hardcoded, we should find a better way
             dicPath = ConfigurationManager.AppSettings["dicPath"] ?? @"Programs\DiscImageCreator.exe";
-            psxtPath = ConfigurationManager.AppSettings["psxt001zPath"] ?? "psxt001z.exe";
             subdumpPath = ConfigurationManager.AppSettings["subdumpPath"] ?? "subdump.exe";
             defaultOutputPath = ConfigurationManager.AppSettings["defaultOutputPath"] ?? "ISO";
         }

--- a/OptionsWindow.xaml
+++ b/OptionsWindow.xaml
@@ -26,24 +26,19 @@
                     <RowDefinition/>
                     <RowDefinition/>
                     <RowDefinition/>
-                    <RowDefinition/>
                 </Grid.RowDefinitions>
 
                 <Label Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Content="DicImageCreator Path:" FontWeight="Bold"/>
                 <TextBox x:Name="txt_dicPath" Grid.Row="0" Grid.Column="1" Height="22" HorizontalAlignment="Stretch" />
                 <Button x:Name="btn_dicPath" Grid.Row="0" Grid.Column="2" Height="22" Width="22" Content="..." Click="btn_BrowseForPath_Click" />
 
-                <Label Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Content="psxt001z Path:" FontWeight="Bold"/>
-                <TextBox x:Name="txt_psxtPath" Grid.Row="1" Grid.Column="1" Height="22" HorizontalAlignment="Stretch" />
-                <Button x:Name="btn_psxtPath" Grid.Row="1" Grid.Column="2" Height="22" Width="22" Content="..." Click="btn_BrowseForPath_Click" />
+                <Label Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Content="subdump Path:" FontWeight="Bold"/>
+                <TextBox x:Name="txt_subdumpPath" Grid.Row="1" Grid.Column="1" Height="22" HorizontalAlignment="Stretch" />
+                <Button x:Name="btn_subdumpPath" Grid.Row="1" Grid.Column="2" Height="22" Width="22" Content="..." Click="btn_BrowseForPath_Click"/>
 
-                <Label Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Content="subdump Path:" FontWeight="Bold"/>
-                <TextBox x:Name="txt_subdumpPath" Grid.Row="2" Grid.Column="1" Height="22" HorizontalAlignment="Stretch" />
-                <Button x:Name="btn_subdumpPath" Grid.Row="2" Grid.Column="2" Height="22" Width="22" Content="..." Click="btn_BrowseForPath_Click"/>
-
-                <Label Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Content="Default Output Path:" FontWeight="Bold"/>
-                <TextBox x:Name="txt_defaultOutputPath" Grid.Row="3" Grid.Column="1" Height="22" HorizontalAlignment="Stretch" />
-                <Button x:Name="btn_defaultOutputPath" Grid.Row="3" Grid.Column="2" Height="22" Width="22" Content="..." Click="btn_BrowseForPath_Click" />
+                <Label Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Content="Default Output Path:" FontWeight="Bold"/>
+                <TextBox x:Name="txt_defaultOutputPath" Grid.Row="2" Grid.Column="1" Height="22" HorizontalAlignment="Stretch" />
+                <Button x:Name="btn_defaultOutputPath" Grid.Row="2" Grid.Column="2" Height="22" Width="22" Content="..." Click="btn_BrowseForPath_Click" />
 
             </Grid>
 

--- a/OptionsWindow.xaml.cs
+++ b/OptionsWindow.xaml.cs
@@ -1,17 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 using System.IO;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Forms;
 using Button = System.Windows.Controls.Button;
 using TextBox = System.Windows.Controls.TextBox;
@@ -51,7 +40,7 @@ namespace DICUI
 
         private string[] PathSettings()
         {
-            string[] pathSettings = { "defaultOutputPath", "dicPath", "psxtPath", "subdumpPath" };
+            string[] pathSettings = { "defaultOutputPath", "dicPath", "subdumpPath" };
             return pathSettings;
         }
 

--- a/Utilities/Converters.cs
+++ b/Utilities/Converters.cs
@@ -264,6 +264,7 @@ namespace DICUI.Utilities
                             break;
                         case KnownSystem.SonyPlayStation:
                             parameters.Add(DICFlags.ScanAntiMod);
+                            parameters.Add(DICFlags.NoFixSubQLibCrypt);
                             break;
                     }
                     break;

--- a/Utilities/DumpInformation.cs
+++ b/Utilities/DumpInformation.cs
@@ -440,12 +440,6 @@ namespace DICUI.Utilities
             {
                 try
                 {
-                    // Make sure this file is a _disc.txt
-                    if (sr.ReadLine() != "========== DiscStructure ==========")
-                    {
-                        return false;
-                    }
-
                     // Check for either antimod string
                     string line = sr.ReadLine().Trim();
                     while (!sr.EndOfStream)
@@ -489,12 +483,6 @@ namespace DICUI.Utilities
             {
                 try
                 {
-                    // Make sure this file is a _disc.txt
-                    if (sr.ReadLine() != "========== DiscStructure ==========")
-                    {
-                        return null;
-                    }
-
                     // Fast forward to the layerbreak
                     while (!sr.ReadLine().Trim().StartsWith("EndDataSector")) ;
 
@@ -561,12 +549,6 @@ namespace DICUI.Utilities
             {
                 try
                 {
-                    // Make sure this file is a _mainInfo.txt
-                    if (sr.ReadLine() != "========== LBA[000016, 0x00010]: Main Channel ==========")
-                    {
-                        return null;
-                    }
-
                     // Fast forward to the PVD
                     while (!sr.ReadLine().StartsWith("0310")) ;
 
@@ -782,12 +764,6 @@ namespace DICUI.Utilities
             {
                 try
                 {
-                    // Make sure this file is a _disc.txt for XBOX
-                    if (sr.ReadLine() != "========== Lock state ==========")
-                    {
-                        return false;
-                    }
-
                     // Fast forward to the Security Sector Ranges
                     while (!sr.ReadLine().Trim().StartsWith("Number of security sector ranges:")) ;
 
@@ -838,12 +814,6 @@ namespace DICUI.Utilities
             {
                 try
                 {
-                    // Make sure this file is a _disc.txt
-                    if (sr.ReadLine() != "========== TOC ==========")
-                    {
-                        return null;
-                    }
-
                     // Fast forward to the offsets
                     while (!sr.ReadLine().Trim().StartsWith("========== Offset")) ;
                     sr.ReadLine(); // Combined Offset

--- a/Utilities/DumpInformation.cs
+++ b/Utilities/DumpInformation.cs
@@ -950,12 +950,6 @@ namespace DICUI.Utilities
                     case KnownSystem.AppleMacintosh:
                     case KnownSystem.IBMPCCompatible:
                         output.Add(Template.CopyProtectionField + ": " + info[Template.CopyProtectionField]); output.Add("");
-
-                        if (info.ContainsKey(Template.SubIntentionField))
-                        {
-                            output.Add(Template.SubIntentionField + ":"); output.Add("");
-                            output.AddRange(info[Template.SubIntentionField].Split('\n'));
-                        }
                         break;
                     case KnownSystem.MicrosoftXBOX:
                     case KnownSystem.MicrosoftXBOX360XDG2:
@@ -966,6 +960,11 @@ namespace DICUI.Utilities
                         output.Add(Template.XBOXSSRanges + ":"); output.Add("");
                         output.AddRange(info[Template.XBOXSSRanges].Split('\n'));
                         break;
+                }
+                if (info.ContainsKey(Template.SubIntentionField))
+                {
+                    output.Add(Template.SubIntentionField + ":"); output.Add("");
+                    output.AddRange(info[Template.SubIntentionField].Split('\n'));
                 }
                 switch (type)
                 {

--- a/Utilities/DumpInformation.cs
+++ b/Utilities/DumpInformation.cs
@@ -162,12 +162,12 @@ namespace DICUI.Utilities
                     mappings[Template.MouldSIDField] = Template.RequiredIfExistsValue;
                     mappings[Template.AdditionalMouldField] = Template.RequiredIfExistsValue;
                     mappings[Template.ToolstampField] = Template.RequiredIfExistsValue;
-                    mappings[Template.PVDField] = GetPVD(combinedBase + "_mainInfo.txt");
+                    mappings[Template.PVDField] = GetPVD(combinedBase + "_mainInfo.txt") ?? "";
                     mappings[Template.ErrorCountField] = GetErrorCount(combinedBase + ".img_EdcEcc.txt",
                         combinedBase + "_c2Error.txt",
                         combinedBase + "_mainError.txt").ToString();
-                    mappings[Template.CuesheetField] = GetFullFile(combinedBase + ".cue");
-                    mappings[Template.WriteOffsetField] = GetWriteOffset(combinedBase + "_disc.txt");
+                    mappings[Template.CuesheetField] = GetFullFile(combinedBase + ".cue") ?? "";
+                    mappings[Template.WriteOffsetField] = GetWriteOffset(combinedBase + "_disc.txt") ?? "";
 
                     // System-specific options
                     switch (sys)
@@ -181,21 +181,21 @@ namespace DICUI.Utilities
                                 FileInfo fi = new FileInfo(combinedBase + "_subIntention.txt");
                                 if (fi.Length > 0)
                                 {
-                                    mappings[Template.SubIntentionField] = GetFullFile(combinedBase + "_subIntention.txt");
+                                    mappings[Template.SubIntentionField] = GetFullFile(combinedBase + "_subIntention.txt") ?? "";
                                 }
                             }
                             break;
                         case KnownSystem.SegaSaturn:
-                            mappings[Template.SaturnHeaderField] = GetSaturnHeader(GetFirstTrack(outputDirectory, outputFilename)).ToString();
+                            mappings[Template.SaturnHeaderField] = GetSaturnHeader(GetFirstTrack(outputDirectory, outputFilename)) ?? "";
                             if (GetSaturnBuildInfo(mappings[Template.SaturnHeaderField], out string serial, out string version, out string buildDate))
                             {
-                                mappings[Template.DiscSerialField] = serial;
-                                mappings[Template.VersionField] = version;
-                                mappings[Template.SaturnBuildDateField] = buildDate;
+                                mappings[Template.DiscSerialField] = serial ?? "";
+                                mappings[Template.VersionField] = version ?? "";
+                                mappings[Template.SaturnBuildDateField] = buildDate ?? "";
                             }
                             break;
                         case KnownSystem.SonyPlayStation:
-                            mappings[Template.PlaystationEXEDateField] = GetPlayStationEXEDate(driveLetter);
+                            mappings[Template.PlaystationEXEDateField] = GetPlayStationEXEDate(driveLetter) ?? "";
                             mappings[Template.PlayStationEDCField] = GetMissingEDCCount(combinedBase + ".img_eccEdc.txt") > 0 ? "No" : "Yes";
                             mappings[Template.PlayStationAntiModchipField] = GetAntiModchipDetected(combinedBase + "_disc.txt") ? "Yes" : "No";
                             mappings[Template.PlayStationLibCryptField] = "No";
@@ -205,14 +205,14 @@ namespace DICUI.Utilities
                                 if (fi.Length > 0)
                                 {
                                     mappings[Template.PlayStationLibCryptField] = "Yes";
-                                    mappings[Template.SubIntentionField] = GetFullFile(combinedBase + "_subIntention.txt");
+                                    mappings[Template.SubIntentionField] = GetFullFile(combinedBase + "_subIntention.txt") ?? "";
                                 }
                             }
                             
                             break;
                         case KnownSystem.SonyPlayStation2:
-                            mappings[Template.PlaystationEXEDateField] = GetPlayStationEXEDate(driveLetter);
-                            mappings[Template.VersionField] = GetPlayStation2Version(driveLetter);
+                            mappings[Template.PlaystationEXEDateField] = GetPlayStationEXEDate(driveLetter) ?? "";
+                            mappings[Template.VersionField] = GetPlayStation2Version(driveLetter) ?? "";
                             break;
                     }
 
@@ -239,7 +239,7 @@ namespace DICUI.Utilities
                         mappings[Template.MouldSIDField] = Template.RequiredIfExistsValue;
                         mappings[Template.AdditionalMouldField] = Template.RequiredIfExistsValue;
                         mappings[Template.ToolstampField] = Template.RequiredIfExistsValue;
-                        mappings[Template.PVDField] = GetPVD(combinedBase + "_mainInfo.txt");
+                        mappings[Template.PVDField] = GetPVD(combinedBase + "_mainInfo.txt") ?? "";
                     }
                     // If we have a dual-layer disc
                     else
@@ -261,7 +261,7 @@ namespace DICUI.Utilities
                         mappings[Template.AdditionalMouldField] = Template.RequiredIfExistsValue;
                         mappings["Outer " + Template.ToolstampField] = Template.RequiredIfExistsValue;
                         mappings["Inner " + Template.ToolstampField] = Template.RequiredIfExistsValue;
-                        mappings[Template.PVDField] = GetPVD(combinedBase + "_mainInfo.txt");
+                        mappings[Template.PVDField] = GetPVD(combinedBase + "_mainInfo.txt") ?? "";
                         mappings[Template.LayerbreakField] = layerbreak;
                     }
 
@@ -277,7 +277,7 @@ namespace DICUI.Utilities
                                 FileInfo fi = new FileInfo(combinedBase + "_subIntention.txt");
                                 if (fi.Length > 0)
                                 {
-                                    mappings[Template.SubIntentionField] = GetFullFile(combinedBase + "_subIntention.txt");
+                                    mappings[Template.SubIntentionField] = GetFullFile(combinedBase + "_subIntention.txt") ?? "";
                                 }
                             }
                             break;
@@ -286,15 +286,15 @@ namespace DICUI.Utilities
                         case KnownSystem.MicrosoftXBOX360XDG3:
                             if (GetXBOXAuxInfo(combinedBase + "_disc.txt", out string dmihash, out string pfihash, out string sshash, out string ss))
                             {
-                                mappings[Template.XBOXDMIHash] = dmihash;
-                                mappings[Template.XBOXPFIHash] = pfihash;
-                                mappings[Template.XBOXSSHash] = sshash;
-                                mappings[Template.XBOXSSRanges] = ss;
+                                mappings[Template.XBOXDMIHash] = dmihash ?? "";
+                                mappings[Template.XBOXPFIHash] = pfihash ?? "";
+                                mappings[Template.XBOXSSHash] = sshash ?? "";
+                                mappings[Template.XBOXSSRanges] = ss ?? "";
                             }
                             break;
                         case KnownSystem.SonyPlayStation2:
-                            mappings[Template.PlaystationEXEDateField] = GetPlayStationEXEDate(driveLetter);
-                            mappings[Template.VersionField] = GetPlayStation2Version(driveLetter);
+                            mappings[Template.PlaystationEXEDateField] = GetPlayStationEXEDate(driveLetter) ?? "";
+                            mappings[Template.VersionField] = GetPlayStation2Version(driveLetter) ?? "";
                             break;
                     }
                     break;

--- a/Utilities/DumpInformation.cs
+++ b/Utilities/DumpInformation.cs
@@ -198,21 +198,15 @@ namespace DICUI.Utilities
                             mappings[Template.PlaystationEXEDateField] = GetPlayStationEXEDate(driveLetter);
                             mappings[Template.PlayStationEDCField] = GetMissingEDCCount(combinedBase + ".img_eccEdc.txt") > 0 ? "No" : "Yes";
                             mappings[Template.PlayStationAntiModchipField] = GetAntiModchipDetected(combinedBase + "_disc.txt") ? "Yes" : "No";
+                            mappings[Template.PlayStationLibCryptField] = "No";
                             if (File.Exists(combinedBase + "_subIntention.txt"))
                             {
                                 FileInfo fi = new FileInfo(combinedBase + "_subIntention.txt");
                                 if (fi.Length > 0)
                                 {
                                     mappings[Template.PlayStationLibCryptField] = "Yes";
+                                    mappings[Template.SubIntentionField] = GetFullFile(combinedBase + "_subIntention.txt");
                                 }
-                                else
-                                {
-                                    mappings[Template.PlayStationLibCryptField] = "No";
-                                }
-                            }
-                            else
-                            {
-                                mappings[Template.PlayStationLibCryptField] = "No";
                             }
                             
                             break;

--- a/Utilities/DumpInformation.cs
+++ b/Utilities/DumpInformation.cs
@@ -964,7 +964,7 @@ namespace DICUI.Utilities
                 if (info.ContainsKey(Template.SubIntentionField))
                 {
                     output.Add(Template.SubIntentionField + ":"); output.Add("");
-                    output.AddRange(info[Template.SubIntentionField].Split('\n'));
+                    output.AddRange(info[Template.SubIntentionField].Split('\n')); output.Add("");
                 }
                 switch (type)
                 {

--- a/Utilities/DumpInformation.cs
+++ b/Utilities/DumpInformation.cs
@@ -198,7 +198,23 @@ namespace DICUI.Utilities
                             mappings[Template.PlaystationEXEDateField] = GetPlayStationEXEDate(driveLetter);
                             mappings[Template.PlayStationEDCField] = GetMissingEDCCount(combinedBase + ".img_eccEdc.txt") > 0 ? "No" : "Yes";
                             mappings[Template.PlayStationAntiModchipField] = GetAntiModchipDetected(combinedBase + "_disc.txt") ? "Yes" : "No";
-                            mappings[Template.PlayStationLibCryptField] = Template.YesNoValue;
+                            if (File.Exists(combinedBase + "_subIntention.txt"))
+                            {
+                                FileInfo fi = new FileInfo(combinedBase + "_subIntention.txt");
+                                if (fi.Length > 0)
+                                {
+                                    mappings[Template.PlayStationLibCryptField] = "Yes";
+                                }
+                                else
+                                {
+                                    mappings[Template.PlayStationLibCryptField] = "No";
+                                }
+                            }
+                            else
+                            {
+                                mappings[Template.PlayStationLibCryptField] = "No";
+                            }
+                            
                             break;
                         case KnownSystem.SonyPlayStation2:
                             mappings[Template.PlaystationEXEDateField] = GetPlayStationEXEDate(driveLetter);

--- a/Utilities/DumpInformation.cs
+++ b/Utilities/DumpInformation.cs
@@ -220,10 +220,10 @@ namespace DICUI.Utilities
                 case MediaType.DVD:
                 case MediaType.HDDVD:
                 case MediaType.BluRay:
-                    string layerbreak = GetLayerbreak(combinedBase + "_disc.txt");
+                    string layerbreak = GetLayerbreak(combinedBase + "_disc.txt") ?? "";
                     
                     // If we have a single-layer disc
-                    if (layerbreak == null)
+                    if (String.IsNullOrWhiteSpace(layerbreak))
                     {
                         switch (type)
                         {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,36 @@
+# version format
+version: 1.06_{build}
+
+# vm template
+image: Visual Studio 2017
+
+# environment variables
+environment:
+  EnableNuGetPackageRestore: true
+
+# msbuild configuration
+platform:
+- AnyCPU
+configuration:
+- Debug
+
+# install dependencies
+install:
+- ps: appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+
+# pre-build script
+before_build:
+- nuget restore
+
+# build step
+build:
+  verbosity: minimal
+
+# post-build step
+after_build:
+- 7z a dicui_%APPVEYOR_BUILD_VERSION%.zip bin\Debug
+
+# artifact linking
+artifacts:
+- path: dicui_$(version).zip
+  name: DICUI


### PR DESCRIPTION
The current code can have >=3 calls to some functions in a row due to a misunderstanding on how the setting of an index triggers the change events. This PR should remove the worst offenders for duplicate calls, presumably making startup and some item changes a lot smoother.

For the PSX automation, there are the following changes:
- EDC check becomes automatic, due to similarities in how the error count and EDC are checked
- Anti-modchip string check becomes automatic thanks to the `/am` flag (Thanks to TonyLizard for helping find this)
- LibCrypt check becomes automatic thanks to the `/nl` flag and the existence of the `_subIntention.txt` file, similar to SecuROM for PC discs (Thanks to TonyLizard for helping find this)

Because of that last item, psxt001z is no longer needed, and has been removed with this PR.

Unintentionally , this PR also addresses some issues that have been persistent due to some assumptions.