### PR TITLE
Streamline Callbacks and Ensure MediaType

### DIFF
--- a/Data/Constants.cs
+++ b/Data/Constants.cs
@@ -14,11 +14,17 @@ namespace DICUI.Data
         public const string StopDumping = "Stop Dumping";
         public const string FloppyDriveString = "<<FLOPPY>>";
 
+        // Private lists of known drive speed ranges
         private static IReadOnlyList<int> AllowedDriveSpeedsForCD { get; } = new List<int> { 1, 2, 3, 4, 6, 8, 12, 16, 20, 24, 32, 40, 44, 48, 52, 56, 72 };
         private static IReadOnlyList<int> AllowedDriveSpeedsForDVD { get; } = AllowedDriveSpeedsForCD.Where(s => s <= 24).ToList();
         private static IReadOnlyList<int> AllowedDriveSpeedsForBD { get; } = AllowedDriveSpeedsForCD.Where(s => s <= 16).ToList();
-        private static IReadOnlyList<int> AllowedDriveSpeedsForUnknownType { get; } = AllowedDriveSpeedsForCD; /*TODO: all or maybe just 1? eg new List<int> { 1 };*/
+        private static IReadOnlyList<int> AllowedDriveSpeedsForUnknownType { get; } = AllowedDriveSpeedsForCD; // TODO: All or {1}? Maybe null?
 
+        /// <summary>
+        /// Get list of all drive speeds for a given MediaType
+        /// </summary>
+        /// <param name="type">MediaType? that represents the current item</param>
+        /// <returns>Read-only list of drive speeds</returns>
         public static IReadOnlyList<int> GetAllowedDriveSpeedsForMediaType(MediaType? type)
         {
             switch (type)
@@ -32,19 +38,19 @@ namespace DICUI.Data
                 case MediaType.WiiOpticalDisc:
                 case MediaType.WiiUOpticalDisc:
                     return AllowedDriveSpeedsForDVD;
-                //TODO: we should return them all since DIC doens't support them in any case
                 case MediaType.BluRay:
                     return AllowedDriveSpeedsForBD;
                 default:
-                    return AllowedDriveSpeedsForUnknownType;             
+                    return AllowedDriveSpeedsForUnknownType;
             }
         }
 
-        public static DoubleCollection GetDoubleCollectionFromIntList(IReadOnlyList<int> list) 
-            => new DoubleCollection(list.Select(i => Convert.ToDouble(i)).ToList());
-
+        // Create collections for UI based on known drive speeds
         public static DoubleCollection AllowedDriveSpeedsForCDAsCollection { get; } = GetDoubleCollectionFromIntList(AllowedDriveSpeedsForCD);
         public static DoubleCollection AllowedDriveSpeedsForDVDAsCollection { get; } = GetDoubleCollectionFromIntList(AllowedDriveSpeedsForDVD);
+        public static DoubleCollection AllowedDriveSpeedsForBDAsCollection { get; } = GetDoubleCollectionFromIntList(AllowedDriveSpeedsForBD);
+        private static DoubleCollection GetDoubleCollectionFromIntList(IReadOnlyList<int> list)
+            => new DoubleCollection(list.Select(i => Convert.ToDouble(i)).ToList());
     }
 
     /// <summary>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -207,13 +207,13 @@ namespace DICUI
             if (cmb_DriveLetter.Items.Count > 0)
             {
                 cmb_DriveLetter.SelectedIndex = 0;
-                lbl_Status.Content = "Valid optical disc found! Choose your Disc Type";
+                lbl_Status.Content = "Valid media found! Choose your Media Type";
                 btn_StartStop.IsEnabled = true;
             }
             else
             {
                 cmb_DriveLetter.SelectedIndex = -1;
-                lbl_Status.Content = "No valid optical disc found!";
+                lbl_Status.Content = "No valid media found!";
                 btn_StartStop.IsEnabled = false;
             }
         }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -355,21 +355,11 @@ namespace DICUI
             // If we're on an unsupported type, update the status accordingly
             switch (type)
             {
-                case MediaType.NONE:
-                    return Result.Failure("Please select a valid disc type");
-                case MediaType.GameCubeGameDisc:
-                case MediaType.GDROM:
-                    return Result.Success("{0} discs are partially supported by DIC", type.Name());
+                // Fully supported types
+                case MediaType.CD:
+                case MediaType.DVD:
                 case MediaType.HDDVD:
-                case MediaType.LaserDisc:
-                case MediaType.CED:
-                case MediaType.UMD:
-                case MediaType.WiiOpticalDisc:
-                case MediaType.WiiUOpticalDisc:
-                case MediaType.Cartridge:
-                case MediaType.Cassette:
-                    return Result.Failure("{0} discs are not currently supported by DIC", type.Name());
-                default:
+                case MediaType.BluRay:
                     if (system == KnownSystem.MicrosoftXBOX360XDG3)
                     {
                         return Result.Failure("{0} discs are not currently supported by DIC", type.Name());
@@ -393,12 +383,29 @@ namespace DICUI
                                 return Result.Success("Disc of type {0} found, but the current system does not support it!", _currentMediaType.Name());
                             }
                         }
-
                     }
-                    break;
-            }
+                    return Result.Success("{0} ready to dump", type.Name());
 
-            return Result.Success("{0} ready to dump", type.Name());
+                // Partially supported types
+                case MediaType.GDROM:
+                case MediaType.GameCubeGameDisc:
+                case MediaType.WiiOpticalDisc:
+                case MediaType.WiiUOpticalDisc:
+                    return Result.Success("{0} discs are partially supported by DIC", type.Name());
+
+                // Undumpable but recognized types
+                case MediaType.LaserDisc:
+                case MediaType.CED:
+                case MediaType.UMD:
+                case MediaType.Cartridge:
+                case MediaType.Cassette:
+                    return Result.Failure("{0} discs are not currently supported by DIC", type.Name());
+
+                // Invalid or unknown types
+                case MediaType.NONE:
+                default:
+                    return Result.Failure("Please select a valid disc type");
+            }
         }
 
         /// <summary>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -39,10 +39,6 @@ namespace DICUI
 
             // Populate the list of drives
             PopulateDrives();
-
-            // Populate the list of drive speeds
-            PopulateDriveSpeeds();
-            SetSupportedDriveSpeed();
         }
 
         #region Events
@@ -74,17 +70,11 @@ namespace DICUI
         private void btn_Search_Click(object sender, RoutedEventArgs e)
         {
             PopulateDrives();
-            SetCurrentDiscType();
-            SetSupportedDriveSpeed();
-            EnsureDiscInformation();
         }
 
         private void cmb_SystemType_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             PopulateMediaTypeAccordingToChosenSystem();
-            SetSupportedDriveSpeed();
-            GetOutputNames();
-            EnsureDiscInformation();
         }
 
         private void cmb_MediaType_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -96,18 +86,14 @@ namespace DICUI
             }
 
             // TODO: This is giving people the benefit of the doubt that their change is valid
-            PopulateDriveSpeeds();
             SetSupportedDriveSpeed();
-            GetOutputNames();
-            EnsureDiscInformation();
         }
 
         private void cmb_DriveLetter_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             SetCurrentDiscType();
-            SetSupportedDriveSpeed();
             GetOutputNames();
-            EnsureDiscInformation();
+            SetSupportedDriveSpeed();
         }
 
         private void cmb_DriveSpeed_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -458,16 +444,13 @@ namespace DICUI
             if (cmb_DriveSpeed.Items == null || cmb_DriveSpeed.Items.Count == 0)
             {
                 PopulateDriveSpeeds();
-                return;
             }
-
-            // Set generic drive speed just in case
-            cmb_DriveSpeed.SelectedItem = 8;
 
             // Get the drive letter from the selected item
             var selected = cmb_DriveLetter.SelectedItem as KeyValuePair<char, string>?;
             if (selected == null || (selected?.Value == UIElements.FloppyDriveString))
             {
+                cmb_DriveSpeed.SelectedItem = 8;
                 return;
             }
 
@@ -478,6 +461,7 @@ namespace DICUI
             if (!File.Exists(_options.dicPath) ||
                 Path.GetFullPath(_options.dicPath) == Path.GetFullPath(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName))
             {
+                cmb_DriveSpeed.SelectedItem = 8;
                 return;
             }
 
@@ -501,6 +485,7 @@ namespace DICUI
             string readspeed = Regex.Match(output.Substring(index), @"ReadSpeedMaximum: [0-9]+KB/sec \(([0-9]*)x\)").Groups[1].Value;
             if (!Int32.TryParse(readspeed, out int speed) || speed <= 0)
             {
+                cmb_DriveSpeed.SelectedItem = 8;
                 return;
             }
 
@@ -511,7 +496,7 @@ namespace DICUI
                 _options.preferredDumpSpeedCD
             );
 
-            cmb_DriveSpeed.SelectedValue = chosenSpeed; cmb_DriveSpeed.SelectedValue = _driveSpeeds.Where(s => s < speed).Last();
+            cmb_DriveSpeed.SelectedValue = chosenSpeed;
         }
 
         /// <summary>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -472,7 +472,7 @@ namespace DICUI
             }
 
             //Validators.GetDriveSpeed((char)selected?.Key);
-            //Validators.GetDriveSpeedEx((char)selected?.Key, MediaType.CD);
+            //Validators.GetDriveSpeedEx((char)selected?.Key, _currentMediaType);
 
             // Validate that the required program exists and it's not DICUI itself
             if (!File.Exists(_options.dicPath) ||

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -82,14 +82,22 @@ namespace DICUI
         private void cmb_SystemType_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             PopulateMediaTypeAccordingToChosenSystem();
+            SetSupportedDriveSpeed();
             GetOutputNames();
             EnsureDiscInformation();
         }
 
-        private void cmb_MediaType_SelectionChanged(object sencder, SelectionChangedEventArgs e)
+        private void cmb_MediaType_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            // Only change the media type if the selection and not the list has changed
+            if (e.RemovedItems.Count == 1 && e.AddedItems.Count == 1)
+            {
+                _currentMediaType = cmb_MediaType.SelectedItem as MediaType?;
+            }
+
             // TODO: This is giving people the benefit of the doubt that their change is valid
-            _currentMediaType = cmb_MediaType.SelectedItem as MediaType?;
+            PopulateDriveSpeeds();
+            SetSupportedDriveSpeed();
             GetOutputNames();
             EnsureDiscInformation();
         }
@@ -158,7 +166,7 @@ namespace DICUI
                 cmb_MediaType.ItemsSource = _mediaTypes;
 
                 cmb_MediaType.IsEnabled = _mediaTypes.Count > 1;
-                cmb_MediaType.SelectedIndex = 0;
+                cmb_MediaType.SelectedIndex = (_mediaTypes.IndexOf(_currentMediaType) >= 0 ? _mediaTypes.IndexOf(_currentMediaType) : 0);
             }
             else
             {
@@ -349,7 +357,7 @@ namespace DICUI
                             && selectedSystem != KnownSystem.MicrosoftXBOX
                             && selectedSystem != KnownSystem.MicrosoftXBOX360XDG2
                             && selectedSystem != KnownSystem.MicrosoftXBOX360XDG3
-                                ? (int)cmb_DriveSpeed.SelectedItem + " " : "")
+                                ? (int?)cmb_DriveSpeed.SelectedItem + " " : "")
                         + string.Join(" ", defaultParams);
                 }
             }
@@ -405,7 +413,7 @@ namespace DICUI
                             }
                             else
                             {
-                                return Result.Success("Disc of type {0} found, but the current system does not support it!", type.Name());
+                                return Result.Success("Disc of type {0} found, but the current system does not support it!", _currentMediaType.Name());
                             }
                         }
 
@@ -446,6 +454,13 @@ namespace DICUI
         /// </summary>
         private void SetSupportedDriveSpeed()
         {
+            // If there are no items, set the drive speeds and try again
+            if (cmb_DriveSpeed.Items == null || cmb_DriveSpeed.Items.Count == 0)
+            {
+                PopulateDriveSpeeds();
+                return;
+            }
+
             // Set generic drive speed just in case
             cmb_DriveSpeed.SelectedItem = 8;
 
@@ -496,7 +511,7 @@ namespace DICUI
                 _options.preferredDumpSpeedCD
             );
 
-            cmb_DriveSpeed.SelectedValue = chosenSpeed;
+            cmb_DriveSpeed.SelectedValue = chosenSpeed; cmb_DriveSpeed.SelectedValue = _driveSpeeds.Where(s => s < speed).Last();
         }
 
         /// <summary>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -87,6 +87,7 @@ namespace DICUI
 
             // TODO: This is giving people the benefit of the doubt that their change is valid
             SetSupportedDriveSpeed();
+            GetOutputNames();
         }
 
         private void cmb_DriveLetter_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -202,16 +203,6 @@ namespace DICUI
                 lbl_Status.Content = "No valid media found!";
                 btn_StartStop.IsEnabled = false;
             }
-        }
-
-        /// <summary>
-        /// Get a complete list of (possible) disc drive speeds, and fill the combo box
-        /// </summary>
-        private void PopulateDriveSpeeds()
-        {
-            var values = UIElements.GetAllowedDriveSpeedsForMediaType(_currentMediaType);
-            cmb_DriveSpeed.ItemsSource = values;
-            cmb_DriveSpeed.SelectedIndex = values.Count / 2;
         }
 
         /// <summary>
@@ -440,17 +431,15 @@ namespace DICUI
         /// </summary>
         private void SetSupportedDriveSpeed()
         {
-            // If there are no items, set the drive speeds and try again
-            if (cmb_DriveSpeed.Items == null || cmb_DriveSpeed.Items.Count == 0)
-            {
-                PopulateDriveSpeeds();
-            }
+            // Set the drive speed list that's appropriate
+            var values = UIElements.GetAllowedDriveSpeedsForMediaType(_currentMediaType);
+            cmb_DriveSpeed.ItemsSource = values;
+            cmb_DriveSpeed.SelectedIndex = values.Count / 2;
 
             // Get the drive letter from the selected item
             var selected = cmb_DriveLetter.SelectedItem as KeyValuePair<char, string>?;
             if (selected == null || (selected?.Value == UIElements.FloppyDriveString))
             {
-                cmb_DriveSpeed.SelectedItem = 8;
                 return;
             }
 
@@ -461,7 +450,6 @@ namespace DICUI
             if (!File.Exists(_options.dicPath) ||
                 Path.GetFullPath(_options.dicPath) == Path.GetFullPath(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName))
             {
-                cmb_DriveSpeed.SelectedItem = 8;
                 return;
             }
 
@@ -485,7 +473,6 @@ namespace DICUI
             string readspeed = Regex.Match(output.Substring(index), @"ReadSpeedMaximum: [0-9]+KB/sec \(([0-9]*)x\)").Groups[1].Value;
             if (!Int32.TryParse(readspeed, out int speed) || speed <= 0)
             {
-                cmb_DriveSpeed.SelectedItem = 8;
                 return;
             }
 

--- a/Utilities/Converters.cs
+++ b/Utilities/Converters.cs
@@ -262,7 +262,7 @@ namespace DICUI.Utilities
                 case MediaType.GDROM:
                     return DICCommands.GDROM;
                 case MediaType.HDDVD:
-                    return null;
+                    return DICCommands.DigitalVideoDisc;
                 case MediaType.BluRay:
                     return DICCommands.BluRay;
 
@@ -331,6 +331,7 @@ namespace DICUI.Utilities
                     parameters.Add(DICFlags.C2Opcode); parameters.Add("20");
                     break;
                 case MediaType.HDDVD:
+                    // Currently no defaults set
                     break;
                 case MediaType.BluRay:
                     // Currently no defaults set

--- a/Utilities/Validators.cs
+++ b/Utilities/Validators.cs
@@ -52,7 +52,6 @@ namespace DICUI.Utilities
                 case KnownSystem.MicrosoftXBOX360XDG3:
                     types.Add(MediaType.CD);
                     types.Add(MediaType.DVD);
-                    types.Add(MediaType.HDDVD);
                     break;
                 case KnownSystem.MicrosoftXBOXOne:
                     types.Add(MediaType.BluRay);


### PR DESCRIPTION
This PR does three major things:
- Strips out a lot of redundant calls (due to callbacks firing) as well as reducing the amount of separate helper methods (by one, but it counts)
- Makes the currently detected / selected media type "stickier" so that it persists more properly across changing systems. This also has the ability of showing the "detected disc was X but system does not support it" message in more relevant cases now.
- Makes HD-DVD a first-class citizen, since apparently DiscImageCreator can dump it using the `dvd` command

On the side, this also adds more prototype code and notes for removing DIC as the way to get drive speeds.