### PR TITLE
Remove Disable Beep; Handle Error Case

### DIFF
--- a/DICUI/Utilities/DumpEnvironment.cs
+++ b/DICUI/Utilities/DumpEnvironment.cs
@@ -101,7 +101,12 @@ namespace DICUI.Utilities
                 };
                 childProcess.Start();
                 childProcess.WaitForExit(1000);
-                childProcess.Close();
+
+                // Just in case, we want to push a button 5 times to clear any errors
+                for (int i = 0; i < 5; i++)
+                    childProcess.StandardInput.WriteLine("Y");
+
+                childProcess.Dispose();
             });
         }
 
@@ -140,17 +145,28 @@ namespace DICUI.Utilities
                         CreateNoWindow = true,
                         UseShellExecute = false,
                         RedirectStandardOutput = true,
+                        RedirectStandardInput = true,
                     },
                 };
                 childProcess.Start();
                 childProcess.WaitForExit(1000);
+
+                // Just in case, we want to push a button 5 times to clear any errors
+                for (int i = 0; i < 5; i++)
+                    childProcess.StandardInput.WriteLine("Y");
+
                 string stdout = childProcess.StandardOutput.ReadToEnd();
                 childProcess.Dispose();
                 return stdout;
             });
 
+            // If a drive or argument was invalid, just exit
+            if (output.Contains("Invalid argument"))
+            {
+                return -1;
+            }
             // If we get that the firmware is out of date, tell the user
-            if (output.Contains("[ERROR] This drive isn't latest firmware. Please update."))
+            else if (output.Contains("[ERROR] This drive isn't latest firmware. Please update."))
             {
                 MessageBox.Show($"DiscImageCreator has reported that drive {Drive.Letter} is not updated to the most recent firmware. Please update the firmware for your drive and try again.", "Outdated Firmware", MessageBoxButton.OK, MessageBoxImage.Error);
                 return -1;

--- a/DICUI/Utilities/DumpEnvironment.cs
+++ b/DICUI/Utilities/DumpEnvironment.cs
@@ -100,7 +100,7 @@ namespace DICUI.Utilities
                     },
                 };
                 childProcess.Start();
-                childProcess.WaitForExit();
+                childProcess.WaitForExit(1000);
                 childProcess.Close();
             });
         }
@@ -139,13 +139,11 @@ namespace DICUI.Utilities
                         Arguments = DICCommands.DriveSpeed + " " + Drive.Letter,
                         CreateNoWindow = true,
                         UseShellExecute = false,
-                        RedirectStandardInput = true,
                         RedirectStandardOutput = true,
                     },
                 };
                 childProcess.Start();
                 childProcess.WaitForExit(1000);
-                childProcess.StandardInput.WriteLine("A");
                 string stdout = childProcess.StandardOutput.ReadToEnd();
                 childProcess.Dispose();
                 return stdout;

--- a/DICUI/Utilities/DumpEnvironment.cs
+++ b/DICUI/Utilities/DumpEnvironment.cs
@@ -93,7 +93,7 @@ namespace DICUI.Utilities
                     StartInfo = new ProcessStartInfo()
                     {
                         FileName = DICPath,
-                        Arguments = DICCommands.Eject + " " + Drive.Letter + " " + DICFlags.DisableBeep,
+                        Arguments = DICCommands.Eject + " " + Drive.Letter,
                         CreateNoWindow = true,
                         UseShellExecute = false,
                         RedirectStandardOutput = true,
@@ -101,6 +101,7 @@ namespace DICUI.Utilities
                 };
                 childProcess.Start();
                 childProcess.WaitForExit();
+                childProcess.Close();
             });
         }
 
@@ -135,15 +136,19 @@ namespace DICUI.Utilities
                     StartInfo = new ProcessStartInfo()
                     {
                         FileName = DICPath,
-                        Arguments = DICCommands.DriveSpeed + " " + Drive.Letter + " " + DICFlags.DisableBeep,
+                        Arguments = DICCommands.DriveSpeed + " " + Drive.Letter,
                         CreateNoWindow = true,
                         UseShellExecute = false,
+                        RedirectStandardInput = true,
                         RedirectStandardOutput = true,
                     },
                 };
                 childProcess.Start();
-                childProcess.WaitForExit();
-                return childProcess.StandardOutput.ReadToEnd();
+                childProcess.WaitForExit(1000);
+                childProcess.StandardInput.WriteLine("A");
+                string stdout = childProcess.StandardOutput.ReadToEnd();
+                childProcess.Dispose();
+                return stdout;
             });
 
             // If we get that the firmware is out of date, tell the user


### PR DESCRIPTION
This PR removes the "disable beep" flag from the Eject and Get Drive Speed calls to DIC, since it's not supported for those. This was found from seeing a couple dozen instances of DiscImageCreator sitting in Task Manager after testing. This also makes the drive speed finding more robust so that it tries to fail fast.