### PR TITLE
Unblock and Update

### DIFF
--- a/DICUI/DICUI.csproj
+++ b/DICUI/DICUI.csproj
@@ -68,7 +68,7 @@
   <PropertyGroup />
   <ItemGroup>
     <Reference Include="BurnOutSharp, Version=1.3.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\BurnOutSharp.1.3.6\lib\net461\BurnOutSharp.dll</HintPath>
+      <HintPath>..\packages\BurnOutSharp.1.3.7\lib\net461\BurnOutSharp.dll</HintPath>
     </Reference>
     <Reference Include="LessIO, Version=0.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\LessIO.0.5.0\lib\net40\LessIO.dll</HintPath>

--- a/DICUI/DICUI.csproj
+++ b/DICUI/DICUI.csproj
@@ -67,8 +67,8 @@
   </PropertyGroup>
   <PropertyGroup />
   <ItemGroup>
-    <Reference Include="BurnOutSharp, Version=1.3.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\BurnOutSharp.1.3.7\lib\net461\BurnOutSharp.dll</HintPath>
+    <Reference Include="BurnOutSharp, Version=1.3.7.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\BurnOutSharp.1.3.7.1\lib\net461\BurnOutSharp.dll</HintPath>
     </Reference>
     <Reference Include="LessIO, Version=0.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\LessIO.0.5.0\lib\net40\LessIO.dll</HintPath>
@@ -92,8 +92,8 @@
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
-    <Reference Include="UnshieldSharp, Version=1.4.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UnshieldSharp.1.4.2.1\lib\net461\UnshieldSharp.dll</HintPath>
+    <Reference Include="UnshieldSharp, Version=1.4.2.2, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UnshieldSharp.1.4.2.2\lib\net461\UnshieldSharp.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />

--- a/DICUI/Data/Enumerations.cs
+++ b/DICUI/Data/Enumerations.cs
@@ -185,6 +185,7 @@
         PhilipsCDiDigitalVideo,
         PhotoCD,
         PlayStationGameSharkUpdates,
+        RainbowDisc,
         TaoiKTV,
         TomyKissSite,
         VideoCD,

--- a/DICUI/MainWindow.xaml.cs
+++ b/DICUI/MainWindow.xaml.cs
@@ -470,20 +470,8 @@ namespace DICUI
             KnownSystem? systemType = SystemTypeComboBox.SelectedItem as KnownSystemComboBoxItem;
             MediaType? mediaType = MediaTypeComboBox.SelectedItem as MediaType?;
 
-            if (drive != null
-                && !String.IsNullOrWhiteSpace(drive.VolumeLabel)
-                && !drive.IsFloppy
-                && systemType != null
-                && mediaType != null)
-            {
-                OutputDirectoryTextBox.Text = Path.Combine(_options.DefaultOutputPath, drive.VolumeLabel);
-                OutputFilenameTextBox.Text = drive.VolumeLabel + mediaType.Extension();
-            }
-            else
-            {
-                OutputDirectoryTextBox.Text = _options.DefaultOutputPath;
-                OutputFilenameTextBox.Text = "disc" + mediaType.Extension();
-            }
+            OutputDirectoryTextBox.Text = Path.Combine(_options.DefaultOutputPath, drive?.VolumeLabel ?? string.Empty);
+            OutputFilenameTextBox.Text = (drive?.VolumeLabel ?? "disc") + (mediaType.Extension() ?? ".bin");
         }
 
         /// <summary>

--- a/DICUI/Utilities/Converters.cs
+++ b/DICUI/Utilities/Converters.cs
@@ -548,6 +548,8 @@ namespace DICUI.Utilities
                     return "Photo CD";
                 case KnownSystem.PlayStationGameSharkUpdates:
                     return "PlayStation GameShark Updates";
+                case KnownSystem.RainbowDisc:
+                    return "Rainbow Disc";
                 case KnownSystem.TaoiKTV:
                     return "Tao iKTV";
                 case KnownSystem.TomyKissSite:

--- a/DICUI/Utilities/DumpEnvironment.cs
+++ b/DICUI/Utilities/DumpEnvironment.cs
@@ -614,7 +614,11 @@ namespace DICUI.Utilities
                 switch (System)
                 {
                     case KnownSystem.AppleMacintosh:
+                    case KnownSystem.EnhancedCD:
+                    case KnownSystem.EnhancedDVD:
+                    case KnownSystem.EnhancedBD:
                     case KnownSystem.IBMPCCompatible:
+                    case KnownSystem.RainbowDisc:
                         output.Add(Template.ISBNField + ": " + info[Template.ISBNField]);
                         break;
                 }
@@ -657,7 +661,11 @@ namespace DICUI.Utilities
                 switch (System)
                 {
                     case KnownSystem.AppleMacintosh:
+                    case KnownSystem.EnhancedCD:
+                    case KnownSystem.EnhancedDVD:
+                    case KnownSystem.EnhancedBD:
                     case KnownSystem.IBMPCCompatible:
+                    case KnownSystem.RainbowDisc:
                         output.Add(Template.CopyProtectionField + ": " + info[Template.CopyProtectionField]); output.Add("");
                         break;
                     case KnownSystem.MicrosoftXBOX:

--- a/DICUI/Utilities/DumpEnvironment.cs
+++ b/DICUI/Utilities/DumpEnvironment.cs
@@ -217,12 +217,12 @@ namespace DICUI.Utilities
 
             // Execute additional tools
             progress?.Report(Result.Success("Running any additional tools... please wait!"));
-            result = ExecuteAdditionalToolsAfterDIC();
+            result = await Task.Run(() => ExecuteAdditionalToolsAfterDIC());
             progress?.Report(result);
 
             // Verify dump output and save it
             progress?.Report(Result.Success("Gathering submission information... please wait!"));
-            result = VerifyAndSaveDumpOutput();
+            result = await Task.Run(() => VerifyAndSaveDumpOutput());
             progress?.Report(Result.Success("All submission information gathered!"));
 
             return result;
@@ -294,10 +294,10 @@ namespace DICUI.Utilities
                         return Result.Failure("Error! Could not find subdump!");
 
                     ExecuteSubdump();
-                    break;
+                    return Result.Success("subdump has finished!");
             }
 
-            return Result.Success();
+            return Result.Success("No external tools needed!");
         }
 
         /// <summary>
@@ -410,7 +410,8 @@ namespace DICUI.Utilities
                         case KnownSystem.IBMPCCompatible:
                         case KnownSystem.RainbowDisc:
                             mappings[Template.ISBNField] = Template.OptionalValue;
-                            mappings[Template.CopyProtectionField] = GetCopyProtection() ?? Template.RequiredIfExistsValue;
+                            string protection = GetCopyProtection();
+                            mappings[Template.CopyProtectionField] = (!String.IsNullOrWhiteSpace(protection) ? protection : Template.RequiredIfExistsValue);
                             if (File.Exists(combinedBase + "_subIntention.txt"))
                             {
                                 FileInfo fi = new FileInfo(combinedBase + "_subIntention.txt");
@@ -510,7 +511,8 @@ namespace DICUI.Utilities
                         case KnownSystem.IBMPCCompatible:
                         case KnownSystem.RainbowDisc:
                             mappings[Template.ISBNField] = Template.OptionalValue;
-                            mappings[Template.CopyProtectionField] = GetCopyProtection() ?? Template.RequiredIfExistsValue;
+                            string protection = GetCopyProtection();
+                            mappings[Template.CopyProtectionField] = (!String.IsNullOrWhiteSpace(protection) ? protection : Template.RequiredIfExistsValue);
                             if (File.Exists(combinedBase + "_subIntention.txt"))
                             {
                                 FileInfo fi = new FileInfo(combinedBase + "_subIntention.txt");

--- a/DICUI/Utilities/DumpEnvironment.cs
+++ b/DICUI/Utilities/DumpEnvironment.cs
@@ -408,6 +408,7 @@ namespace DICUI.Utilities
                         case KnownSystem.EnhancedDVD:
                         case KnownSystem.EnhancedBD:
                         case KnownSystem.IBMPCCompatible:
+                        case KnownSystem.RainbowDisc:
                             mappings[Template.ISBNField] = Template.OptionalValue;
                             mappings[Template.CopyProtectionField] = GetCopyProtection() ?? Template.RequiredIfExistsValue;
                             if (File.Exists(combinedBase + "_subIntention.txt"))
@@ -507,6 +508,7 @@ namespace DICUI.Utilities
                         case KnownSystem.EnhancedDVD:
                         case KnownSystem.EnhancedBD:
                         case KnownSystem.IBMPCCompatible:
+                        case KnownSystem.RainbowDisc:
                             mappings[Template.ISBNField] = Template.OptionalValue;
                             mappings[Template.CopyProtectionField] = GetCopyProtection() ?? Template.RequiredIfExistsValue;
                             if (File.Exists(combinedBase + "_subIntention.txt"))

--- a/DICUI/Utilities/Validators.cs
+++ b/DICUI/Utilities/Validators.cs
@@ -356,6 +356,9 @@ namespace DICUI.Utilities
                 case KnownSystem.PlayStationGameSharkUpdates:
                     types.Add(MediaType.CD);
                     break;
+                case KnownSystem.RainbowDisc:
+                    types.Add(MediaType.CD);
+                    break;
                 case KnownSystem.TaoiKTV:
                     types.Add(MediaType.CD);
                     break;

--- a/DICUI/packages.config
+++ b/DICUI/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BurnOutSharp" version="1.3.7" targetFramework="net461" />
+  <package id="BurnOutSharp" version="1.3.7.1" targetFramework="net461" />
   <package id="LessIO" version="0.5.0" targetFramework="net461" />
   <package id="libmspack4n" version="0.8.0" targetFramework="net461" />
-  <package id="UnshieldSharp" version="1.4.2.1" targetFramework="net461" />
+  <package id="UnshieldSharp" version="1.4.2.2" targetFramework="net461" />
   <package id="zlib.net" version="1.0.4.0" targetFramework="net461" />
 </packages>

--- a/DICUI/packages.config
+++ b/DICUI/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BurnOutSharp" version="1.3.6" targetFramework="net461" />
+  <package id="BurnOutSharp" version="1.3.7" targetFramework="net461" />
   <package id="LessIO" version="0.5.0" targetFramework="net461" />
   <package id="libmspack4n" version="0.8.0" targetFramework="net461" />
   <package id="UnshieldSharp" version="1.4.2.1" targetFramework="net461" />


### PR DESCRIPTION
This PR has two major items:
- Update external packages (BurnOutSharp and Unshield)
- Make it so that external tools and submission info creation don't block the main thread

This PR also includes a couple of minor things:
- Added "Rainbow Disc" as a valid output option for the whole, like, 1 disc that falls in that category
- Added more formats to the same output fields as IBM and Macintosh
- Fixed automatic filling of output paths (this one was somehow really broken the old way, often reverting to just "disc". No idea why, but the cleaner code has not run into this issue)