### PR TITLE
Change printable string misspellings relating to DIC 

### DIFF
--- a/DICUI/OptionsWindow.xaml
+++ b/DICUI/OptionsWindow.xaml
@@ -92,7 +92,7 @@
                 <CheckBox Grid.Column="0" VerticalAlignment="Center" Content="Quiet Mode" 
                           DataContext="{Binding Source={x:Static lui:ViewModels.OptionsViewModel}}" 
                           IsChecked="{Binding Path=QuietMode}" 
-                          ToolTip="Disable DiskImageCreator sounds" 
+                          ToolTip="Disable DiscImageCreator sounds" 
                           />
                 <CheckBox Grid.Column="1" VerticalAlignment="Center" Content="Paranoid Mode" 
                           DataContext="{Binding Source={x:Static lui:ViewModels.OptionsViewModel}}" 

--- a/DICUI/Utilities/DumpEnvironment.cs
+++ b/DICUI/Utilities/DumpEnvironment.cs
@@ -312,7 +312,7 @@ namespace DICUI.Utilities
         /// </summary>
         private void ExecuteDiskImageCreator()
         {
-            ViewModels.LoggerViewModel.VerboseLogLn("Launching DiskImageCreator process.");
+            ViewModels.LoggerViewModel.VerboseLogLn("Launching DiscImageCreator process.");
 
             dicProcess = new Process()
             {


### PR DESCRIPTION
On two strings in DICUI, DIC was mispelled _(Disk_ instead of _Disc_ that DIC uses) in the Log and Options windows. This small PR should fix that.
It's mainly just for consistency of the strings in the end. 